### PR TITLE
Rename PWA to "Tesla Solar Charger"

### DIFF
--- a/TeslaSolarCharger/Client/wwwroot/manifest.json
+++ b/TeslaSolarCharger/Client/wwwroot/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Smart Tesla Amp Setter",
-  "short_name": "SmartTeslaAmpSetter",
+  "name": "Tesla Solar Charger",
+  "short_name": "Tesla Solar Charger",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",

--- a/TeslaSolarCharger/Client/wwwroot/manifest.json
+++ b/TeslaSolarCharger/Client/wwwroot/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Smart Tesla Amp Setter",
-  "short_name": "SmartTelsaAmpSetter",
+  "short_name": "SmartTeslaAmpSetter",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",


### PR DESCRIPTION
At first I only wanted to fix the "Telsa" typo in the name of the progressive web app, but then I realized it should completely renamed to "Tesla Solar Charger".