### PR TITLE
Fix issue #652: Merge charges if highest price where car is charging …

### DIFF
--- a/TeslaSolarCharger.Tests/Services/Server/ChargeTimeCalculationService.cs
+++ b/TeslaSolarCharger.Tests/Services/Server/ChargeTimeCalculationService.cs
@@ -157,7 +157,29 @@ public class ChargeTimeCalculationService : TestBase
     }
 
     [Fact]
-    public void DoesConcatenateChargingSlotsCorrectly()
+    public void Does_Concatenate_Charging_Slots_Correctly_One_Partial_Slot_Only()
+    {
+        var chargingSlots = new List<DtoChargingSlot>()
+        {
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 10, 10, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 10, 30, 0, TimeSpan.Zero),
+            },
+        };
+
+        var combinedChargingTimeBeforeConcatenation = chargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum();
+
+        var chargeTimeCalculationService = Mock.Create<TeslaSolarCharger.Server.Services.ChargeTimeCalculationService>();
+        var concatenatedChargingSlots = chargeTimeCalculationService.ConcatenateChargeTimes(chargingSlots);
+
+
+        Assert.Equal(combinedChargingTimeBeforeConcatenation, concatenatedChargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum());
+        Assert.Single(concatenatedChargingSlots);
+    }
+
+    [Fact]
+    public void Does_Concatenate_Charging_Slots_Correctly_Two_Full_Hour_One_Partial_Hour_Last()
     {
         var chargingSlots = new List<DtoChargingSlot>()
         {
@@ -169,7 +191,7 @@ public class ChargeTimeCalculationService : TestBase
             new DtoChargingSlot()
             {
                 ChargeStart = new DateTimeOffset(2022, 1, 10, 11, 0, 0, TimeSpan.Zero),
-                ChargeEnd = new DateTimeOffset(2022, 1, 10, 12, 00, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 12, 0, 0, TimeSpan.Zero),
             },
             new DtoChargingSlot()
             {
@@ -186,6 +208,146 @@ public class ChargeTimeCalculationService : TestBase
 
         Assert.Equal(combinedChargingTimeBeforeConcatenation, concatenatedChargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum());
         Assert.Equal(2, concatenatedChargingSlots.Count);
+    }
+
+    [Fact]
+    public void Does_Concatenate_Charging_Slots_Correctly_Partial_Hour_First()
+    {
+        var chargingSlots = new List<DtoChargingSlot>()
+        {
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 10, 10, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 10, 25, 0, TimeSpan.Zero),
+            },
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 10, 11, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 12, 0, 0, TimeSpan.Zero),
+            },
+        };
+
+        var combinedChargingTimeBeforeConcatenation = chargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum();
+
+        var chargeTimeCalculationService = Mock.Create<TeslaSolarCharger.Server.Services.ChargeTimeCalculationService>();
+        var concatenatedChargingSlots = chargeTimeCalculationService.ConcatenateChargeTimes(chargingSlots);
+
+
+        Assert.Equal(combinedChargingTimeBeforeConcatenation, concatenatedChargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum());
+        Assert.Single(concatenatedChargingSlots);
+    }
+
+    [Fact]
+    public void Does_Concatenate_Charging_Slots_Correctly_Partial_Hour_Last()
+    {
+        var chargingSlots = new List<DtoChargingSlot>()
+        {
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 10, 10, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 11, 0, 0, TimeSpan.Zero),
+            },
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 10, 11, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 11, 20, 0, TimeSpan.Zero),
+            },
+        };
+
+        var combinedChargingTimeBeforeConcatenation = chargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum();
+
+        var chargeTimeCalculationService = Mock.Create<TeslaSolarCharger.Server.Services.ChargeTimeCalculationService>();
+        var concatenatedChargingSlots = chargeTimeCalculationService.ConcatenateChargeTimes(chargingSlots);
+
+
+        Assert.Equal(combinedChargingTimeBeforeConcatenation, concatenatedChargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum());
+        Assert.Single(concatenatedChargingSlots);
+    }
+
+    [Fact]
+    public void Does_Concatenate_Charging_Slots_Correctly_Partial_Hour_Middle()
+    {
+        var chargingSlots = new List<DtoChargingSlot>()
+        {
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 11, 20, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 11, 21, 0, 0, TimeSpan.Zero),
+            },
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 11, 21, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 11, 21, 35, 0, TimeSpan.Zero),
+            },
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 11, 22, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 11, 23, 0, 0, TimeSpan.Zero),
+            },
+        };
+
+        var combinedChargingTimeBeforeConcatenation = chargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum();
+
+        var chargeTimeCalculationService = Mock.Create<TeslaSolarCharger.Server.Services.ChargeTimeCalculationService>();
+        var concatenatedChargingSlots = chargeTimeCalculationService.ConcatenateChargeTimes(chargingSlots);
+
+
+        Assert.Equal(combinedChargingTimeBeforeConcatenation, concatenatedChargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum());
+        Assert.Single(concatenatedChargingSlots);
+    }
+
+    [Fact]
+    public void Does_Concatenate_Charging_Slots_Correctly_Start_Charge_Now()
+    {
+        var chargingSlots = new List<DtoChargingSlot>()
+        {
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 10, 10, 10, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 10, 43, 0, TimeSpan.Zero),
+            },
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 10, 11, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 12, 0, 0, TimeSpan.Zero),
+            },
+        };
+
+        var combinedChargingTimeBeforeConcatenation = chargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum();
+
+        var chargeTimeCalculationService = Mock.Create<TeslaSolarCharger.Server.Services.ChargeTimeCalculationService>();
+        var concatenatedChargingSlots = chargeTimeCalculationService.ConcatenateChargeTimes(chargingSlots);
+
+
+        Assert.Equal(combinedChargingTimeBeforeConcatenation, concatenatedChargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum());
+        Assert.Single(concatenatedChargingSlots);
+    }
+
+    [Fact]
+    public void Does_Concatenate_Charging_Slots_Correctly_Start_Charge_Before_Midnight()
+    {
+        var chargingSlots = new List<DtoChargingSlot>()
+        {
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 10, 23, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 10, 23, 30, 0, TimeSpan.Zero),
+            },
+            new DtoChargingSlot()
+            {
+                ChargeStart = new DateTimeOffset(2022, 1, 11, 0, 0, 0, TimeSpan.Zero),
+                ChargeEnd = new DateTimeOffset(2022, 1, 11, 1, 0, 0, TimeSpan.Zero),
+            },
+        };
+
+        var combinedChargingTimeBeforeConcatenation = chargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum();
+
+        var chargeTimeCalculationService = Mock.Create<TeslaSolarCharger.Server.Services.ChargeTimeCalculationService>();
+        var concatenatedChargingSlots = chargeTimeCalculationService.ConcatenateChargeTimes(chargingSlots);
+
+
+        Assert.Equal(combinedChargingTimeBeforeConcatenation, concatenatedChargingSlots.Select(c => c.ChargeDuration.TotalHours).Sum());
+        Assert.Single(concatenatedChargingSlots);
     }
 
     [Theory, MemberData(nameof(CalculateCorrectChargeTimesWithoutStockPricesData))]

--- a/TeslaSolarCharger/Server/Services/ChargeTimeCalculationService.cs
+++ b/TeslaSolarCharger/Server/Services/ChargeTimeCalculationService.cs
@@ -293,6 +293,13 @@ public class ChargeTimeCalculationService : IChargeTimeCalculationService
             {
                 lastChargingSlot.ChargeEnd = currentChargingSlot.ChargeEnd;
             }
+            // fix #652: if a slot is less than one hour long - and the next one starts in the hour after - merge the two by subtracting the first slot's duration from the start of the second block
+            else if ((currentChargingSlot.ChargeStart - lastChargingSlot.ChargeEnd).Hours == 0)
+            {
+                lastChargingSlot.ChargeStart = currentChargingSlot.ChargeStart.AddSeconds(
+                    (-3600 * lastChargingSlot.ChargeDuration.Hours) - (60 * lastChargingSlot.ChargeDuration.Minutes) - lastChargingSlot.ChargeDuration.Seconds);
+                lastChargingSlot.ChargeEnd = currentChargingSlot.ChargeEnd;
+            }
             else
             {
                 chargingSlots.Add(currentChargingSlot);


### PR DESCRIPTION
…is before cheaper hours

Includes fix and tests for various edge-cases (e.g. midnight-slots and having to start charging now).

Known problems: there is one edge-case that I am aware about that I have intentionally left open:
- when there is a full cheap hour scheduled, then a partial more expensive one, then another cheap one
- all of them must be next to one another with no full hour break in between
- the algorithm will merge the first full hour with the second partial one - all good, no problem so far
- it will then merge the result with the third hour - making the second hour a full one and the first one a partial one
- this could lead to slight additional costs - if the costs for the second hour are a lot higher than for the first
- However - this is an extreme edge-case, usually the hours that are close together have a very similar price -> therefore I have opted to keep this behaviour and prioritize having one full charging session over saving a few cents