### PR TITLE
Stream backup restore to avoid memory spikes

### DIFF
--- a/TeslaSolarCharger/Client/Components/BackupComponent.razor
+++ b/TeslaSolarCharger/Client/Components/BackupComponent.razor
@@ -137,38 +137,22 @@
     private async Task StartRestore()
     {
         _processingRestore = true;
-        bool upload;
         if (_file == default)
         {
             Snackbar.Add("No file selected", Severity.Error);
-            return;
-        }
-        using var content = new MultipartFormDataContent();
-        try
-        {
-            var fileContent = new StreamContent(_file.OpenReadStream(_maxFileSize));
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("multipart/form-data");
-            content.Add(
-                content: fileContent,
-                name: "\"file\"",
-                fileName: _file.Name);
-            upload = true;
-        }
-        catch (Exception e)
-        {
-            Snackbar.Add($"Error while uploading file: {e.Message}", Severity.Error);
             _processingRestore = false;
             return;
         }
-        if (!upload)
-        {
-            _processingRestore = false;
-            return;
-        }
+
         try
         {
+            await using var fileStream = _file.OpenReadStream(_maxFileSize);
+            using var streamContent = new StreamContent(fileStream);
+            streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
             using var httpClient = HttpClientFactory.CreateClient(StaticConstants.LongTimeOutHttpClientName);
-            var response = await httpClient.PostAsync("api/BaseConfiguration/RestoreBackup", content);
+            var response = await httpClient.PostAsync($"api/BaseConfiguration/RestoreBackup?fileName={Uri.EscapeDataString(_file.Name)}", streamContent);
+
             if (response.IsSuccessStatusCode)
             {
                 Snackbar.Add("Backup file saved. Container restart required to complete restore. Please restart the TSC container now.", Severity.Success);
@@ -178,15 +162,13 @@
             {
                 Snackbar.Add($"Error while restoring backup: {response.ReasonPhrase}", Severity.Error);
             }
-            
         }
         catch (Exception e)
         {
             Snackbar.Add($"Fatal Error while restoring backup: {e.Message}", Severity.Error);
             Logger.LogError(e, "Error while restoring backup");
-            _processingRestore = false;
-            return;
         }
+
         _processingRestore = false;
     }
 

--- a/TeslaSolarCharger/Client/Program.cs
+++ b/TeslaSolarCharger/Client/Program.cs
@@ -1,5 +1,6 @@
 using ApexCharts;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.AspNetCore.Components.WebAssembly.Http;
 using MudBlazor;
 using MudBlazor.Services;
 using MudExtensions.Services;
@@ -25,14 +26,26 @@ builder.Services.AddHttpClient(StaticConstants.LongTimeOutHttpClientName, client
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
     // Add other configurations like timeout, default headers, etc.
     client.Timeout = TimeSpan.FromMinutes(10);
+}).ConfigurePrimaryHttpMessageHandler(() => new WebAssemblyHttpMessageHandler
+{
+    EnableStreamingRequest = true,
+    EnableStreamingResponse = true
 });
 
 builder.Services.AddHttpClient(StaticConstants.NormalTimeOutHttpClientName, client =>
 {
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+}).ConfigurePrimaryHttpMessageHandler(() => new WebAssemblyHttpMessageHandler
+{
+    EnableStreamingRequest = true,
+    EnableStreamingResponse = true
 });
 
-builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped(_ => new HttpClient(new WebAssemblyHttpMessageHandler
+{
+    EnableStreamingRequest = true,
+    EnableStreamingResponse = true
+}) { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 //builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri("http://192.168.1.50:7189/") });
 builder.Services.AddScoped<INodePatternTypeHelper, NodePatternTypeHelper>();
 builder.Services.AddScoped<IDateTimeProvider, DateTimeProvider>();

--- a/TeslaSolarCharger/Server/Contracts/IBaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Contracts/IBaseConfigurationService.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using TeslaSolarCharger.Shared.Dtos;
+﻿using TeslaSolarCharger.Shared.Dtos;
 using TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
+using System.IO;
 
 namespace TeslaSolarCharger.Server.Contracts;
 
@@ -9,7 +9,7 @@ public interface IBaseConfigurationService
     Task UpdateBaseConfigurationAsync(DtoBaseConfiguration baseConfiguration);
     Task UpdateMaxCombinedCurrent(int? maxCombinedCurrent);
     Task UpdatePowerBuffer(int powerBuffer);
-    Task RestoreBackup(IFormFile file);
+    Task RestoreBackup(Stream fileStream, string fileName);
     Task<string> CreateLocalBackupZipFile(string backupFileNamePrefix, string? backupZipDestinationDirectory, bool clearBackupDirectoryBeforeBackup);
     List<DtoBackupFileInformation> GetAutoBackupFileInformations();
     Task<byte[]> DownloadAutoBackup(string fileName);

--- a/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
+++ b/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
@@ -57,9 +57,10 @@ namespace TeslaSolarCharger.Server.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> RestoreBackup(IFormFile file)
+        [RequestSizeLimit(long.MaxValue)]
+        public async Task<IActionResult> RestoreBackup([FromQuery] string fileName)
         {
-            await service.RestoreBackup(file).ConfigureAwait(false);
+            await service.RestoreBackup(Request.Body, fileName).ConfigureAwait(false);
             return Ok();
         }
 

--- a/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Data.Sqlite;
+using System.IO;
 using System.IO.Compression;
 using TeslaSolarCharger.Model.Contracts;
 using TeslaSolarCharger.Server.Contracts;
@@ -118,9 +119,9 @@ public class BaseConfigurationService(
     }
 
 
-    public async Task RestoreBackup(IFormFile file)
+    public async Task RestoreBackup(Stream fileStream, string fileName)
     {
-        logger.LogTrace("{method}({file})", nameof(RestoreBackup), file.FileName);
+        logger.LogTrace("{method}({file})", nameof(RestoreBackup), fileName);
 
         try
         {
@@ -132,7 +133,7 @@ public class BaseConfigurationService(
             var pendingRestoreFilePath = Path.Combine(pendingRestoreDirectory, pendingRestoreFileName);
 
             await using FileStream fs = new(pendingRestoreFilePath, FileMode.Create);
-            await file.CopyToAsync(fs).ConfigureAwait(false);
+            await fileStream.CopyToAsync(fs).ConfigureAwait(false);
             fs.Close();
 
             settings.RestartNeeded = true;


### PR DESCRIPTION
## Summary
- stream backup upload from client to prevent buffering large files
- enable streaming request handlers for Blazor WebAssembly HttpClients
- adjust controller and service to accept streamed backup data

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4994ef87c83249018cbb6a4b8bcc7