### PR TITLE
Stream backup restore to avoid memory errors

### DIFF
--- a/TeslaSolarCharger/Client/Components/BackupComponent.razor
+++ b/TeslaSolarCharger/Client/Components/BackupComponent.razor
@@ -137,38 +137,18 @@
     private async Task StartRestore()
     {
         _processingRestore = true;
-        bool upload;
         if (_file == default)
         {
             Snackbar.Add("No file selected", Severity.Error);
-            return;
-        }
-        using var content = new MultipartFormDataContent();
-        try
-        {
-            var fileContent = new StreamContent(_file.OpenReadStream(_maxFileSize));
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("multipart/form-data");
-            content.Add(
-                content: fileContent,
-                name: "\"file\"",
-                fileName: _file.Name);
-            upload = true;
-        }
-        catch (Exception e)
-        {
-            Snackbar.Add($"Error while uploading file: {e.Message}", Severity.Error);
-            _processingRestore = false;
-            return;
-        }
-        if (!upload)
-        {
             _processingRestore = false;
             return;
         }
         try
         {
+            using var streamContent = new StreamContent(_file.OpenReadStream(_maxFileSize));
+            streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
             using var httpClient = HttpClientFactory.CreateClient(StaticConstants.LongTimeOutHttpClientName);
-            var response = await httpClient.PostAsync("api/BaseConfiguration/RestoreBackup", content);
+            var response = await httpClient.PostAsync($"api/BaseConfiguration/RestoreBackup?fileName={Uri.EscapeDataString(_file.Name)}", streamContent);
             if (response.IsSuccessStatusCode)
             {
                 Snackbar.Add("Backup file saved. Container restart required to complete restore. Please restart the TSC container now.", Severity.Success);
@@ -178,7 +158,6 @@
             {
                 Snackbar.Add($"Error while restoring backup: {response.ReasonPhrase}", Severity.Error);
             }
-            
         }
         catch (Exception e)
         {

--- a/TeslaSolarCharger/Server/Contracts/IBaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Contracts/IBaseConfigurationService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.IO;
 using TeslaSolarCharger.Shared.Dtos;
 using TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
 
@@ -9,7 +9,7 @@ public interface IBaseConfigurationService
     Task UpdateBaseConfigurationAsync(DtoBaseConfiguration baseConfiguration);
     Task UpdateMaxCombinedCurrent(int? maxCombinedCurrent);
     Task UpdatePowerBuffer(int powerBuffer);
-    Task RestoreBackup(IFormFile file);
+    Task RestoreBackup(Stream fileStream, string fileName);
     Task<string> CreateLocalBackupZipFile(string backupFileNamePrefix, string? backupZipDestinationDirectory, bool clearBackupDirectoryBeforeBackup);
     List<DtoBackupFileInformation> GetAutoBackupFileInformations();
     Task<byte[]> DownloadAutoBackup(string fileName);

--- a/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
+++ b/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
@@ -57,9 +57,10 @@ namespace TeslaSolarCharger.Server.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> RestoreBackup(IFormFile file)
+        [DisableRequestSizeLimit]
+        public async Task<IActionResult> RestoreBackup([FromQuery] string fileName)
         {
-            await service.RestoreBackup(file).ConfigureAwait(false);
+            await service.RestoreBackup(Request.Body, fileName).ConfigureAwait(false);
             return Ok();
         }
 

--- a/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
@@ -118,9 +118,9 @@ public class BaseConfigurationService(
     }
 
 
-    public async Task RestoreBackup(IFormFile file)
+    public async Task RestoreBackup(Stream fileStream, string fileName)
     {
-        logger.LogTrace("{method}({file})", nameof(RestoreBackup), file.FileName);
+        logger.LogTrace("{method}({file})", nameof(RestoreBackup), fileName);
 
         try
         {
@@ -132,8 +132,7 @@ public class BaseConfigurationService(
             var pendingRestoreFilePath = Path.Combine(pendingRestoreDirectory, pendingRestoreFileName);
 
             await using FileStream fs = new(pendingRestoreFilePath, FileMode.Create);
-            await file.CopyToAsync(fs).ConfigureAwait(false);
-            fs.Close();
+            await fileStream.CopyToAsync(fs).ConfigureAwait(false);
 
             settings.RestartNeeded = true;
 


### PR DESCRIPTION
## Summary
- stream backup uploads from client to server to avoid buffering entire file
- accept raw stream on server, disabling request size limits during restore
- adjust service and contract to handle stream uploads

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4994ef87c83249018cbb6a4b8bcc7