### PR TITLE
Handle large backup restore uploads in chunks

### DIFF
--- a/TeslaSolarCharger/Client/Components/BackupComponent.razor
+++ b/TeslaSolarCharger/Client/Components/BackupComponent.razor
@@ -53,22 +53,24 @@
         @_file.Name <code>@((_file.Size * 0.000001).ToString("0.00")) MB</code>
     </div>
 }
-<RightAlignedButtonComponent IsDisabled="@(_processingBackup || _processingRestore || _file == default)"
-                             DisabledToolTipText=""
-                             OnButtonClicked="StartRestore"
-                             IsLoading="_processingRestore"
-                             ButtonText="Start restore"></RightAlignedButtonComponent>
-@if(UploadProgress != default && UploadProgress.Value != null && UploadProgress.MaxValue != null)
+
+@if (UploadProgress != default && UploadProgress.Value != null && UploadProgress.MaxValue != null)
 {
     <div class="mb-3">
         <MudProgressLinear Value="UploadProgress.Value.Value"
                            Max="UploadProgress.MaxValue.Value"
                            Size="Size.Large"
                            Striped="true"
-                           Color="Color.Primary"/>
+                           Color="Color.Primary" />
     </div>
-
 }
+
+<RightAlignedButtonComponent IsDisabled="@(_processingBackup || _processingRestore || _file == default)"
+                             DisabledToolTipText=""
+                             OnButtonClicked="StartRestore"
+                             IsLoading="_processingRestore"
+                             ButtonText="Start restore"></RightAlignedButtonComponent>
+
 <MudExpansionPanels>
     <MudExpansionPanel Text="Automatically created backups before each update" ExpandedChanged="RefreshBackups">
         <MudDataGrid Items="_backupFiles">
@@ -92,7 +94,7 @@
 @code {
     private bool _processingBackup;
     private bool _processingRestore;
-    private readonly long _maxFileSize = 1024 * 1024 * 1024; // 1024 MB
+    private const long MaxFileSize = 4294967296; // 4GB
     private List<DtoBackupFileInformation> _backupFiles = new List<DtoBackupFileInformation>();
     private IBrowserFile? _file;
     private DotNetObjectReference<BackupComponent>? _objRef;
@@ -138,9 +140,9 @@
         {
             return;
         }
-        if (file.Size > _maxFileSize)
+        if (file.Size > MaxFileSize)
         {
-            Snackbar.Add($"{file.Name} is greater than {_maxFileSize / 1024 / 1024} and won't be uploaded."
+            Snackbar.Add($"{file.Name} is greater than {MaxFileSize / 1024 / 1024} and won't be uploaded."
                 , Severity.Error);
         }
         _file = file;
@@ -164,7 +166,8 @@
             using var httpClient = HttpClientFactory.CreateClient(StaticConstants.LongTimeOutHttpClientName);
             var chunkSize = 10 * 1024 * 1024;
             var totalChunks = (int)Math.Ceiling((double)_file.Size / chunkSize);
-            await using var stream = _file.OpenReadStream(_maxFileSize);
+            var stream = _file.OpenReadStream(MaxFileSize);
+            await using var stream1 = stream.ConfigureAwait(true);
             var buffer = new byte[chunkSize];
             var chunkNumber = 0;
             int bytesRead;

--- a/TeslaSolarCharger/Client/Components/BackupComponent.razor
+++ b/TeslaSolarCharger/Client/Components/BackupComponent.razor
@@ -1,5 +1,5 @@
 ﻿@page "/backupAndRestore"
-@using System.Net.Http.Headers
+@using TeslaSolarCharger.Shared
 @using TeslaSolarCharger.Shared.Dtos
 @using TeslaSolarCharger.Shared.Resources
 @inject IJSRuntime JsRuntime
@@ -58,6 +58,17 @@
                              OnButtonClicked="StartRestore"
                              IsLoading="_processingRestore"
                              ButtonText="Start restore"></RightAlignedButtonComponent>
+@if(UploadProgress != default && UploadProgress.Value != null && UploadProgress.MaxValue != null)
+{
+    <div class="mb-3">
+        <MudProgressLinear Value="UploadProgress.Value.Value"
+                           Max="UploadProgress.MaxValue.Value"
+                           Size="Size.Large"
+                           Striped="true"
+                           Color="Color.Primary"/>
+    </div>
+
+}
 <MudExpansionPanels>
     <MudExpansionPanel Text="Automatically created backups before each update" ExpandedChanged="RefreshBackups">
         <MudDataGrid Items="_backupFiles">
@@ -85,6 +96,7 @@
     private List<DtoBackupFileInformation> _backupFiles = new List<DtoBackupFileInformation>();
     private IBrowserFile? _file;
     private DotNetObjectReference<BackupComponent>? _objRef;
+    private DtoProgress? UploadProgress { get; set; }
 
     protected override void OnInitialized()
     {
@@ -137,56 +149,61 @@
     private async Task StartRestore()
     {
         _processingRestore = true;
-        bool upload;
         if (_file == default)
         {
             Snackbar.Add("No file selected", Severity.Error);
-            return;
-        }
-        using var content = new MultipartFormDataContent();
-        try
-        {
-            var fileContent = new StreamContent(_file.OpenReadStream(_maxFileSize));
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("multipart/form-data");
-            content.Add(
-                content: fileContent,
-                name: "\"file\"",
-                fileName: _file.Name);
-            upload = true;
-        }
-        catch (Exception e)
-        {
-            Snackbar.Add($"Error while uploading file: {e.Message}", Severity.Error);
             _processingRestore = false;
             return;
         }
-        if (!upload)
-        {
-            _processingRestore = false;
-            return;
-        }
+
+        UploadProgress = new DtoProgress { Value = 0, MaxValue = _file.Size };
+        await InvokeAsync(StateHasChanged);
+
         try
         {
             using var httpClient = HttpClientFactory.CreateClient(StaticConstants.LongTimeOutHttpClientName);
-            var response = await httpClient.PostAsync("api/BaseConfiguration/RestoreBackup", content);
-            if (response.IsSuccessStatusCode)
+            var chunkSize = 10 * 1024 * 1024;
+            var totalChunks = (int)Math.Ceiling((double)_file.Size / chunkSize);
+            await using var stream = _file.OpenReadStream(_maxFileSize);
+            var buffer = new byte[chunkSize];
+            var chunkNumber = 0;
+            int bytesRead;
+            while ((bytesRead = await stream.ReadAsync(buffer, 0, chunkSize)) > 0)
             {
-                Snackbar.Add("Backup file saved. Container restart required to complete restore. Please restart the TSC container now.", Severity.Success);
-                _file = null; // Clear the selected file
+                chunkNumber++;
+                using var content = new MultipartFormDataContent();
+                var byteContent = new ByteArrayContent(buffer, 0, bytesRead);
+                content.Add(byteContent, "file", _file.Name);
+                content.Add(new StringContent(_file.Name), "fileName");
+                content.Add(new StringContent(chunkNumber.ToString()), "chunkNumber");
+                content.Add(new StringContent(totalChunks.ToString()), "totalChunks");
+
+                var response = await httpClient.PostAsync("api/BaseConfiguration/RestoreBackup", content);
+                if (!response.IsSuccessStatusCode)
+                {
+                    Snackbar.Add($"Error while restoring backup: {response.ReasonPhrase}", Severity.Error);
+                    _processingRestore = false;
+                    UploadProgress = null;
+                    return;
+                }
+
+                UploadProgress.Value += bytesRead;
+                await InvokeAsync(StateHasChanged);
             }
-            else
-            {
-                Snackbar.Add($"Error while restoring backup: {response.ReasonPhrase}", Severity.Error);
-            }
-            
+
+            Snackbar.Add("Backup file saved. Container restart required to complete restore. Please restart the TSC container now.", Severity.Success);
+            _file = null;
+            UploadProgress = null;
         }
         catch (Exception e)
         {
             Snackbar.Add($"Fatal Error while restoring backup: {e.Message}", Severity.Error);
             Logger.LogError(e, "Error while restoring backup");
+            UploadProgress = null;
             _processingRestore = false;
             return;
         }
+
         _processingRestore = false;
     }
 

--- a/TeslaSolarCharger/Server/Contracts/IBaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Contracts/IBaseConfigurationService.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using TeslaSolarCharger.Shared.Dtos;
 using TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
 
@@ -9,7 +10,7 @@ public interface IBaseConfigurationService
     Task UpdateBaseConfigurationAsync(DtoBaseConfiguration baseConfiguration);
     Task UpdateMaxCombinedCurrent(int? maxCombinedCurrent);
     Task UpdatePowerBuffer(int powerBuffer);
-    Task RestoreBackup(IFormFile file);
+    Task RestoreBackup(IFormFile file, string fileName, int chunkNumber, int totalChunks);
     Task<string> CreateLocalBackupZipFile(string backupFileNamePrefix, string? backupZipDestinationDirectory, bool clearBackupDirectoryBeforeBackup);
     List<DtoBackupFileInformation> GetAutoBackupFileInformations();
     Task<byte[]> DownloadAutoBackup(string fileName);

--- a/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
+++ b/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
@@ -57,9 +57,13 @@ namespace TeslaSolarCharger.Server.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> RestoreBackup(IFormFile file)
+        public async Task<IActionResult> RestoreBackup(
+            IFormFile file,
+            [FromForm] string fileName,
+            [FromForm] int chunkNumber,
+            [FromForm] int totalChunks)
         {
-            await service.RestoreBackup(file).ConfigureAwait(false);
+            await service.RestoreBackup(file, fileName, chunkNumber, totalChunks).ConfigureAwait(false);
             return Ok();
         }
 

--- a/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
@@ -136,7 +136,8 @@ public class BaseConfigurationService(
 
             var tempFilePath = Path.Combine(pendingRestoreDirectory, $"{fileName}.part");
 
-            await using (var fs = new FileStream(tempFilePath, FileMode.Append, FileAccess.Write))
+            var fs = new FileStream(tempFilePath, FileMode.Append, FileAccess.Write);
+            await using (fs.ConfigureAwait(false))
             {
                 await file.CopyToAsync(fs).ConfigureAwait(false);
             }

--- a/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
@@ -175,6 +175,17 @@ public class BaseConfigurationService(
         if (files.Length == 0)
         {
             logger.LogInformation("No pending restore files found in: {pendingRestorePath}", pendingRestorePath);
+            try
+            {
+                foreach (var file in Directory.GetFiles(pendingRestorePath))
+                {
+                    File.Delete(file);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Couldn't clean up pending restore directory: {pendingRestorePath}", pendingRestorePath);
+            }
             return;
         }
 

--- a/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
@@ -118,26 +118,41 @@ public class BaseConfigurationService(
     }
 
 
-    public async Task RestoreBackup(IFormFile file)
+    public async Task RestoreBackup(IFormFile file, string fileName, int chunkNumber, int totalChunks)
     {
-        logger.LogTrace("{method}({file})", nameof(RestoreBackup), file.FileName);
+        logger.LogTrace("{method}({file}, {chunkNumber}, {totalChunks})", nameof(RestoreBackup), file.FileName, chunkNumber, totalChunks);
 
         try
         {
-            // Save file to pending restore directory
             var pendingRestoreDirectory = configurationWrapper.PendingRestoreDirectory();
-            CreateDirectory(pendingRestoreDirectory);
+            if (chunkNumber == 1)
+            {
+                CreateDirectory(pendingRestoreDirectory);
+            }
+            else if (!Directory.Exists(pendingRestoreDirectory))
+            {
+                Directory.CreateDirectory(pendingRestoreDirectory);
+            }
 
-            var pendingRestoreFileName = $"pending-restore-{dateTimeProvider.DateTimeOffSetUtcNow().ToLocalTime():yyyy-MM-dd-HH-mm-ss}.zip";
-            var pendingRestoreFilePath = Path.Combine(pendingRestoreDirectory, pendingRestoreFileName);
+            var tempFilePath = Path.Combine(pendingRestoreDirectory, $"{fileName}.part");
 
-            await using FileStream fs = new(pendingRestoreFilePath, FileMode.Create);
-            await file.CopyToAsync(fs).ConfigureAwait(false);
-            fs.Close();
+            await using (var fs = new FileStream(tempFilePath, FileMode.Append, FileAccess.Write))
+            {
+                await file.CopyToAsync(fs).ConfigureAwait(false);
+            }
 
-            settings.RestartNeeded = true;
-
-            logger.LogInformation("Backup file saved for restore after container restart: {filePath}", pendingRestoreFilePath);
+            if (chunkNumber == totalChunks)
+            {
+                var pendingRestoreFileName = $"pending-restore-{dateTimeProvider.DateTimeOffSetUtcNow().ToLocalTime():yyyy-MM-dd-HH-mm-ss}.zip";
+                var pendingRestoreFilePath = Path.Combine(pendingRestoreDirectory, pendingRestoreFileName);
+                if (File.Exists(pendingRestoreFilePath))
+                {
+                    File.Delete(pendingRestoreFilePath);
+                }
+                File.Move(tempFilePath, pendingRestoreFilePath);
+                settings.RestartNeeded = true;
+                logger.LogInformation("Backup file saved for restore after container restart: {filePath}", pendingRestoreFilePath);
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Send backup restore files in 10MB chunks with upload progress bar
- Accept chunked uploads on the server and assemble backup file

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aa1b7be88324a530df1f46f51259