### PR TITLE
Enable manual SoC updates for manual cars

### DIFF
--- a/TeslaSolarCharger/Client/Components/StartPage/CarDetailsComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/CarDetailsComponent.razor
@@ -62,10 +62,7 @@ else
         <div class="mt-3">
             <GenericInput T="int?"
                           For="() => ManualSocToSet"
-                          ImmediateValueUpdate="true" />
-            <RightAlignedButtonComponent ButtonText="Set State of Charge"
-                                         IsLoading="@_isManualSocLoading"
-                                         OnButtonClicked="@(SetManualSoc)" />
+                          OnValueChanged="SetManualSoc"/>
         </div>
     }
     <div>
@@ -359,10 +356,8 @@ else
             }
 
             Snackbar.Add("State of charge updated successfully.", Severity.Success);
-            if (CarState != default)
-            {
-                CarState.Soc = manualSoc;
-            }
+            ManualSocToSet = null;
+            StateHasChanged();
         }
         finally
         {

--- a/TeslaSolarCharger/Client/Components/StartPage/CarDetailsComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/CarDetailsComponent.razor
@@ -1,5 +1,6 @@
 ﻿@using TeslaSolarCharger.Client.Helper.Contracts
 @using TeslaSolarCharger.Client.Services.Contracts
+@using System.ComponentModel
 @using TeslaSolarCharger.Shared.Attributes
 @using TeslaSolarCharger.Shared.Dtos.Home
 @using TeslaSolarCharger.Shared.Enums
@@ -55,6 +56,17 @@ else
                                     BufferLabelPrefix="Car Limit: "
                                     BufferLabelSuffix="%">
         </ProgressWithLabelComponent>
+    }
+    @if (CarSettings.CarType == CarType.Manual)
+    {
+        <div class="mt-3">
+            <GenericInput T="int?"
+                          For="() => ManualSocToSet"
+                          ImmediateValueUpdate="true" />
+            <RightAlignedButtonComponent ButtonText="Set State of Charge"
+                                         IsLoading="@_isManualSocLoading"
+                                         OnButtonClicked="@(SetManualSoc)" />
+        </div>
     }
     <div>
         <div class="d-flex align-items-center">
@@ -129,7 +141,11 @@ else
 
     [Postfix("A")]
     private int? CurrentToSet { get; set; }
+    [DisplayName("State of Charge")]
+    [Postfix("%")]
+    private int? ManualSocToSet { get; set; }
     private bool _isCommandLoading;
+    private bool _isManualSocLoading;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -147,6 +163,10 @@ else
                 try
                 {
                     CarState = state;
+                    if (CarSettings?.CarType == CarType.Manual)
+                    {
+                        ManualSocToSet = state?.Soc;
+                    }
                     await InvokeAsync(StateHasChanged);
                 }
                 catch (Exception e)
@@ -159,6 +179,10 @@ else
         CarState = await SignalRStateService.GetStateAsync<DtoCarOverviewState>(
             DataTypeConstants.CarOverviewState,
             CarId.Value.ToString());
+        if (CarSettings?.CarType == CarType.Manual)
+        {
+            ManualSocToSet = CarState?.Soc;
+        }
     }
 
     private async Task RefreshData()
@@ -301,6 +325,48 @@ else
         else
         {
             Snackbar.Add("Command successfully sent", Severity.Success);
+        }
+    }
+
+    private async Task SetManualSoc()
+    {
+        if (CarId == default)
+        {
+            return;
+        }
+
+        if (ManualSocToSet == default)
+        {
+            Snackbar.Add("Please set a valid state of charge.", Severity.Error);
+            return;
+        }
+
+        var manualSoc = ManualSocToSet.Value;
+        if (manualSoc < 0 || manualSoc > 100)
+        {
+            Snackbar.Add("State of charge must be between 0 and 100%.", Severity.Error);
+            return;
+        }
+
+        _isManualSocLoading = true;
+        try
+        {
+            var result = await HomeService.UpdateManualCarSoc(CarId.Value, manualSoc);
+            if (result.HasError)
+            {
+                Snackbar.Add($"Error: {result.ErrorMessage}", Severity.Error);
+                return;
+            }
+
+            Snackbar.Add("State of charge updated successfully.", Severity.Success);
+            if (CarState != default)
+            {
+                CarState.Soc = manualSoc;
+            }
+        }
+        finally
+        {
+            _isManualSocLoading = false;
         }
     }
 

--- a/TeslaSolarCharger/Client/Services/Contracts/IHomeService.cs
+++ b/TeslaSolarCharger/Client/Services/Contracts/IHomeService.cs
@@ -22,6 +22,7 @@ public interface IHomeService
     Task<Result<object?>> SetChargingConnectorCurrent(int chargingConnectorId, int currentToSet, int? numberOfPhases);
     Task<Result<object?>> StopChargingConnectorCharging(int chargingConnectorId);
     Task<Result<object?>> SetCarChargingCurrent(int carId, int currentToSet);
+    Task<Result<object?>> UpdateManualCarSoc(int carId, int soc);
     Task<Result<object?>> UpdateCarMaxSoc(int carId, int soc);
     Task<List<DtoNotChargingWithExpectedPowerReason>?> GetNotChargingWithExpectedPowerReasons(int? carId, int? connectorId);
     Task<Dictionary<int, string>?> GetLoadPointCarOptions();

--- a/TeslaSolarCharger/Client/Services/HomeService.cs
+++ b/TeslaSolarCharger/Client/Services/HomeService.cs
@@ -138,6 +138,13 @@ public class HomeService : IHomeService
         return result;
     }
 
+    public async Task<Result<object?>> UpdateManualCarSoc(int carId, int soc)
+    {
+        _logger.LogTrace("{method}({carId}, {soc})", nameof(UpdateManualCarSoc), carId, soc);
+        var result = await _httpClientHelper.SendPostRequestAsync<object?>($"api/Home/UpdateManualCarSoc?carId={carId}&soc={soc}", null);
+        return result;
+    }
+
     public async Task<Result<object>> DeleteCarChargingTarget(int chargingTargetId)
     {
         _logger.LogTrace("{method}()", nameof(DeleteCarChargingTarget));

--- a/TeslaSolarCharger/Server/Controllers/HomeController.cs
+++ b/TeslaSolarCharger/Server/Controllers/HomeController.cs
@@ -138,6 +138,13 @@ public class HomeController : ApiBaseController
         return Ok();
     }
 
+    [HttpPost]
+    public async Task<IActionResult> UpdateManualCarSoc(int carId, int soc)
+    {
+        await _homeService.UpdateManualCarSoc(carId, soc);
+        return Ok();
+    }
+
     [HttpGet]
     public IActionResult GetNotChargingWithExpectedPowerReasons(int? carId, int? connectorId)
     {

--- a/TeslaSolarCharger/Server/Services/Contracts/IHomeService.cs
+++ b/TeslaSolarCharger/Server/Services/Contracts/IHomeService.cs
@@ -22,6 +22,7 @@ public interface IHomeService
     Task SetChargingConnectorCurrent(int chargingConnectorId, int currentToSet, int? numberOfPhases, CancellationToken cancellationToken);
     Task StopChargingConnectorCharging(int chargingConnectorId, CancellationToken cancellationToken);
     Task UpdateCarMaxSoc(int carId, int newSoc);
+    Task UpdateManualCarSoc(int carId, int newSoc);
     Dictionary<int, string> GetLoadPointCarOptions();
     Task<Dictionary<DateTimeOffset, decimal>> GetGridPrices(DateTimeOffset from, DateTimeOffset to);
 }


### PR DESCRIPTION
## Summary
- add a manual state-of-charge input for manual car types on the home page using GenericInput
- extend the home service contract, client implementation, and API controller with a manual SoC update endpoint
- persist manual SoC updates in the server service and trigger real-time refreshes for connected clients

## Testing
- dotnet test TeslaSolarCharger.sln *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0154249488324a60f4f31c3eea173