### PR TITLE
Scope manual car initialization to startup and new manual cars

### DIFF
--- a/TeslaSolarCharger/Server/Contracts/IConfigJsonService.cs
+++ b/TeslaSolarCharger/Server/Contracts/IConfigJsonService.cs
@@ -13,7 +13,7 @@ public interface IConfigJsonService
     Task UpdateCarBasicConfiguration(int carId, CarBasicConfiguration carBasicConfiguration);
     Task<List<CarBasicConfiguration>> GetCarBasicConfigurations();
     ISettings GetSettings();
-    Task AddCarsToSettings();
+    Task AddCarsToSettings(bool initializeManualCarValues = false, int? manualCarIdToInitialize = null);
     Task AddBleBaseUrlToAllCars();
     Task SetCorrectHomeDetectionVia();
 }

--- a/TeslaSolarCharger/Server/Program.cs
+++ b/TeslaSolarCharger/Server/Program.cs
@@ -351,7 +351,7 @@ async Task DoStartupStuff(WebApplication webApplication, ILogger<Program> logger
                 // Ignore this error as this could result in never taking the first token
             }
         }
-        await configJsonService.AddCarsToSettings().ConfigureAwait(false);
+        await configJsonService.AddCarsToSettings(initializeManualCarValues: true).ConfigureAwait(false);
 
 
         var pvValueService = startupScope.ServiceProvider.GetRequiredService<IPvValueService>();


### PR DESCRIPTION
## Summary
- add optional parameters to AddCarsToSettings/GetCars so manual car defaults can be initialized selectively
- move manual car default value handling into a helper so only targeted manual cars are updated
- trigger manual initialization only for new manual cars and during startup configuration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d18c1d9e8883249b9b1a9abbe2e0c3