### PR TITLE
Localize Home page strings

### DIFF
--- a/TeslaSolarCharger/Client/Pages/Home.razor
+++ b/TeslaSolarCharger/Client/Pages/Home.razor
@@ -12,7 +12,7 @@
 @inject ISignalRStateService SignalRStateService
 @inject IStringLocalizer<Home> Localizer
 
-<PageTitle>Solar 4 Car</PageTitle>
+<PageTitle>@Localizer["Solar 4 Car"]</PageTitle>
 
 <MerryChristmasAndHappyNewYearComponent></MerryChristmasAndHappyNewYearComponent>
 
@@ -40,7 +40,14 @@ else
     if (_loadPoints.Count < 1)
     {
         <MudAlert Severity="Severity.Info" Class="mb-3">
-            No cars and no charging stations should be managed. Check out <MudLink Href="CarSettings">Car Settings</MudLink> to add a car or <MudLink Href="ChargingStations">Charging Stations</MudLink> to add a charging station.
+            <p>@Localizer["No cars and no charging stations should be managed."]</p>
+            <p>
+                @Localizer["Check out"]
+                <MudLink Href="CarSettings">@Localizer["Car Settings"]</MudLink>
+                @Localizer["to add a car or"]
+                <MudLink Href="ChargingStations">@Localizer["Charging Stations"]</MudLink>
+                @Localizer["to add a charging station."]
+            </p>
         </MudAlert>
     }
 }
@@ -53,7 +60,7 @@ else
 <form action="https://www.paypal.com/donate" method="post" target="_blank">
     <div style="text-align:center">
         <input type="hidden" name="hosted_button_id" value="RJMHGCTVU6TWJ" />
-        <input type="image" src="DonateWithPaypal.png" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" />
+        <input type="image" src="DonateWithPaypal.png" border="0" name="submit" title="@Localizer["PayPal - The safer, easier way to pay online!"]" alt="@Localizer["Donate with PayPal button"]" />
         <img alt="" border="0" src="https://www.paypal.com/en_DE/i/scr/pixel.gif" width="1" height="1" />
     </div>
 </form>

--- a/TeslaSolarCharger/Client/Resources/Pages/Home.de.resx
+++ b/TeslaSolarCharger/Client/Resources/Pages/Home.de.resx
@@ -121,4 +121,40 @@
     <value>Nutze meinen Weiteremfehlungscode um ein Teslaprodukt zu kaufen, oder um eine Probefahrt zu buchen:</value>
     <comment>Use my referral code for ordering any Tesla product or schedule a Demo Drive:</comment>
   </data>
+  <data name="Solar 4 Car" xml:space="preserve">
+    <value>Solar 4 Car</value>
+    <comment>Solar 4 Car</comment>
+  </data>
+  <data name="No cars and no charging stations should be managed." xml:space="preserve">
+    <value>Es sollten keine Autos und keine Ladestationen verwaltet werden.</value>
+    <comment>No cars and no charging stations should be managed.</comment>
+  </data>
+  <data name="Check out" xml:space="preserve">
+    <value>Schau dir</value>
+    <comment>Check out</comment>
+  </data>
+  <data name="Car Settings" xml:space="preserve">
+    <value>Fahrzeugeinstellungen</value>
+    <comment>Car Settings</comment>
+  </data>
+  <data name="to add a car or" xml:space="preserve">
+    <value>an, um ein Auto hinzuzufügen oder</value>
+    <comment>to add a car or</comment>
+  </data>
+  <data name="Charging Stations" xml:space="preserve">
+    <value>Ladestationen</value>
+    <comment>Charging Stations</comment>
+  </data>
+  <data name="to add a charging station." xml:space="preserve">
+    <value>um eine Ladestation hinzuzufügen.</value>
+    <comment>to add a charging station.</comment>
+  </data>
+  <data name="PayPal - The safer, easier way to pay online!" xml:space="preserve">
+    <value>PayPal – Die sichere, einfache Art, online zu bezahlen!</value>
+    <comment>PayPal - The safer, easier way to pay online!</comment>
+  </data>
+  <data name="Donate with PayPal button" xml:space="preserve">
+    <value>Spenden mit PayPal-Schaltfläche</value>
+    <comment>Donate with PayPal button</comment>
+  </data>
 </root>

--- a/TeslaSolarCharger/Client/Resources/Pages/Home.en.resx
+++ b/TeslaSolarCharger/Client/Resources/Pages/Home.en.resx
@@ -120,4 +120,31 @@
   <data name="Use my referral code for ordering any Tesla product or schedule a Demo Drive:" xml:space="preserve">
     <value>Use my referral code for ordering any Tesla product or schedule a Demo Drive:</value>
   </data>
+  <data name="Solar 4 Car" xml:space="preserve">
+    <value>Solar 4 Car</value>
+  </data>
+  <data name="No cars and no charging stations should be managed." xml:space="preserve">
+    <value>No cars and no charging stations should be managed.</value>
+  </data>
+  <data name="Check out" xml:space="preserve">
+    <value>Check out</value>
+  </data>
+  <data name="Car Settings" xml:space="preserve">
+    <value>Car Settings</value>
+  </data>
+  <data name="to add a car or" xml:space="preserve">
+    <value>to add a car or</value>
+  </data>
+  <data name="Charging Stations" xml:space="preserve">
+    <value>Charging Stations</value>
+  </data>
+  <data name="to add a charging station." xml:space="preserve">
+    <value>to add a charging station.</value>
+  </data>
+  <data name="PayPal - The safer, easier way to pay online!" xml:space="preserve">
+    <value>PayPal - The safer, easier way to pay online!</value>
+  </data>
+  <data name="Donate with PayPal button" xml:space="preserve">
+    <value>Donate with PayPal button</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- replace hard-coded Home page strings with localized resources
- add English and German resource entries for the Home page alert and PayPal content

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68eb8a8b6348832499e40087e1449692