### PR TITLE
Add localization resources for BaseConfiguration page

### DIFF
--- a/TeslaSolarCharger/Client/Pages/BaseConfiguration.razor
+++ b/TeslaSolarCharger/Client/Pages/BaseConfiguration.razor
@@ -1,4 +1,5 @@
 @page "/BaseConfiguration"
+@using Microsoft.Extensions.Localization
 @using TeslaSolarCharger.Client.Helper.Contracts
 @using TeslaSolarCharger.Client.Wrapper
 @using TeslaSolarCharger.Shared.Dtos.BaseConfiguration
@@ -6,11 +7,12 @@
 
 @inject ISnackbar Snackbar
 @inject IHttpClientHelper HttpClientHelper
+@inject IStringLocalizer<BaseConfiguration> Localizer
 
 
-<PageTitle>Base Configuration</PageTitle>
+<PageTitle>@Localizer["Base Configuration"]</PageTitle>
 
-<h1>Base Configuration</h1>
+<h1>@Localizer["Base Configuration"]</h1>
 
 @if (_dtoBaseConfiguration == null)
 {
@@ -21,10 +23,10 @@ else
     <EditFormComponent T="DtoBaseConfiguration" WrappedElement="@(_dtoBaseConfiguration)"
                        OnAfterSuccessfullSubmit="ShowSuccessMessage"
                        SubmitUrl="@("api/BaseConfiguration/UpdateBaseConfiguration")">
-        <h3>General:</h3>
+        <h3>@Localizer["General:"]</h3>
         <GenericInput For="() => _dtoBaseConfiguration.Item.MaxCombinedCurrent" />
         <hr />
-        <h3>TeslaMate:</h3>
+        <h3>@Localizer["TeslaMate:"]</h3>
         <GenericInput T="bool"
         For="() => _dtoBaseConfiguration.Item.UseTeslaMateIntegration"
         OnValueChanged="_ => InvokeAsync(StateHasChanged)"></GenericInput>
@@ -42,15 +44,15 @@ else
         }
 
 
-        <h3>Home Geofence</h3>
+        <h3>@Localizer["Home Geofence"]</h3>
         <div class="mb-3">
             <MapComponent Longitude="_dtoBaseConfiguration.Item.HomeGeofenceLongitude"
             Latitude="_dtoBaseConfiguration.Item.HomeGeofenceLatitude"
             Radius="_dtoBaseConfiguration.Item.HomeGeofenceRadius"
             LatitudeChanged="@(newLatitude => _dtoBaseConfiguration.Item.HomeGeofenceLatitude = newLatitude)"
-            LongitudeChanged="@(newLongitude => { _dtoBaseConfiguration.Item.HomeGeofenceLongitude = newLongitude; Snackbar.Add("To update the location, click the save button on the bottom of the page", Severity.Info); })"></MapComponent>
+            LongitudeChanged="@(newLongitude => { _dtoBaseConfiguration.Item.HomeGeofenceLongitude = newLongitude; Snackbar.Add(Localizer["To update the location, click the save button on the bottom of the page"], Severity.Info); })"></MapComponent>
 
-            <small class="form-text text-muted">Click on the map to select your home geofence. Within that area TSC will regulate the charging power.</small>
+            <small class="form-text text-muted">@Localizer["Click on the map to select your home geofence. Within that area TSC will regulate the charging power."]</small>
         </div>
 
         <GenericInput For="() => _dtoBaseConfiguration.Item.HomeGeofenceRadius" />
@@ -86,9 +88,9 @@ else
         <MqttValueConfigurationComponent />
 
         <div class="shadow p-3 mb-5 bg-white rounded">
-            <h3>Telegram:</h3>
-            <a href="https://github.com/pkuehnel/TeslaSolarCharger#telegram-integration" target="_blank">How to set up Telegram</a>
-            <div>Note: The Telegram bot for now only sends messages if something is not working. E.g. The car does not respond to commands, solar power values can not be refreshed,...</div>
+            <h3>@Localizer["Telegram:"]</h3>
+            <a href="https://github.com/pkuehnel/TeslaSolarCharger#telegram-integration" target="_blank">@Localizer["How to set up Telegram"]</a>
+            <div>@Localizer["Note: The Telegram bot for now only sends messages if something is not working. E.g. The car does not respond to commands, solar power values can not be refreshed,..."]</div>
             <GenericInput T="string?"
             For="() => _dtoBaseConfiguration.Item.TelegramBotKey"
             OnValueChanged="@(_ => _telegramSettingsChanged = true)"></GenericInput>
@@ -96,20 +98,20 @@ else
             For="() => _dtoBaseConfiguration.Item.TelegramChannelId"
             OnValueChanged="@(_ => _telegramSettingsChanged = true)"></GenericInput>
             <GenericInput For="() => _dtoBaseConfiguration.Item.SendStackTraceToTelegram"></GenericInput>
-            <RightAlignedButtonComponent ButtonText="Send test message"
+            <RightAlignedButtonComponent ButtonText='@Localizer["Send test message"]'
             IsDisabled="_telegramSettingsChanged"
-            DisabledToolTipText="You need to save the configuration before testing it."
+            DisabledToolTipText='@Localizer["You need to save the configuration before testing it."]'
             OnButtonClicked="_ => SendTelegramTestMessage()"></RightAlignedButtonComponent>
         </div>
 
         <MudExpansionPanels>
-            <MudExpansionPanel Text="Advanced settings. Please only change values here if you know what you are doing.">
+            <MudExpansionPanel Text='@Localizer["Advanced settings. Please only change values here if you know what you are doing."]'>
                 <GenericInput For="() => _dtoBaseConfiguration.Item.UpdateIntervalSeconds" />
                 @if (_dtoBaseConfiguration.Item.SkipPowerChangesOnLastAdjustmentNewerThanSeconds < 25)
                 {
                     <MudAlert Severity="Severity.Warning"
                               ContentAlignment="HorizontalAlignment.Left">
-                        Values blelow 25 seconds are not recommended and might cause performance issues.
+                        @Localizer["Values blelow 25 seconds are not recommended and might cause performance issues."]
                     </MudAlert>
                 }
                 <GenericInput T="int"
@@ -156,7 +158,7 @@ else
 
     private void ShowSuccessMessage()
     {
-        Snackbar.Add("Saved.", Severity.Success);
+        Snackbar.Add(Localizer["Saved."], Severity.Success);
     }
 
     private async Task SendTelegramTestMessage()
@@ -164,7 +166,7 @@ else
         var result = await HttpClientHelper.SendGetRequestWithSnackbarAsync<DtoValue<string>>("api/Hello/SendTestTelegramMessage");
         if (result == default)
         {
-            Snackbar.Add("Could not get result", Severity.Error);
+            Snackbar.Add(Localizer["Could not get result"], Severity.Error);
             return;
         }
 

--- a/TeslaSolarCharger/Client/Resources/Pages/BaseConfiguration.de.resx
+++ b/TeslaSolarCharger/Client/Resources/Pages/BaseConfiguration.de.resx
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Base Configuration" xml:space="preserve">
+    <value>Basiskonfiguration</value>
+  </data>
+  <data name="General:" xml:space="preserve">
+    <value>Allgemein:</value>
+  </data>
+  <data name="TeslaMate:" xml:space="preserve">
+    <value>TeslaMate:</value>
+  </data>
+  <data name="Home Geofence" xml:space="preserve">
+    <value>Home-Geofence</value>
+  </data>
+  <data name="To update the location, click the save button on the bottom of the page" xml:space="preserve">
+    <value>Um den Standort zu aktualisieren, klicken Sie auf die Schaltfläche Speichern am unteren Ende der Seite</value>
+  </data>
+  <data name="Click on the map to select your home geofence. Within that area TSC will regulate the charging power." xml:space="preserve">
+    <value>Klicken Sie auf die Karte, um Ihren Home-Geofence auszuwählen. Innerhalb dieses Bereichs reguliert TSC die Ladeleistung.</value>
+  </data>
+  <data name="Telegram:" xml:space="preserve">
+    <value>Telegram:</value>
+  </data>
+  <data name="How to set up Telegram" xml:space="preserve">
+    <value>So richten Sie Telegram ein</value>
+  </data>
+  <data name="Note: The Telegram bot for now only sends messages if something is not working. E.g. The car does not respond to commands, solar power values can not be refreshed,..." xml:space="preserve">
+    <value>Hinweis: Der Telegram-Bot sendet derzeit nur Nachrichten, wenn etwas nicht funktioniert. z. B. reagiert das Fahrzeug nicht auf Befehle, Solardaten können nicht aktualisiert werden, ...</value>
+  </data>
+  <data name="Send test message" xml:space="preserve">
+    <value>Testnachricht senden</value>
+  </data>
+  <data name="You need to save the configuration before testing it." xml:space="preserve">
+    <value>Sie müssen die Konfiguration speichern, bevor Sie sie testen.</value>
+  </data>
+  <data name="Advanced settings. Please only change values here if you know what you are doing." xml:space="preserve">
+    <value>Erweiterte Einstellungen. Ändern Sie Werte hier nur, wenn Sie wissen, was Sie tun.</value>
+  </data>
+  <data name="Values blelow 25 seconds are not recommended and might cause performance issues." xml:space="preserve">
+    <value>Werte unter 25 Sekunden werden nicht empfohlen und können Leistungsprobleme verursachen.</value>
+  </data>
+  <data name="Saved." xml:space="preserve">
+    <value>Gespeichert.</value>
+  </data>
+  <data name="Could not get result" xml:space="preserve">
+    <value>Ergebnis konnte nicht abgerufen werden</value>
+  </data>
+</root>

--- a/TeslaSolarCharger/Client/Resources/Pages/BaseConfiguration.en.resx
+++ b/TeslaSolarCharger/Client/Resources/Pages/BaseConfiguration.en.resx
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Base Configuration" xml:space="preserve">
+    <value>Base Configuration</value>
+  </data>
+  <data name="General:" xml:space="preserve">
+    <value>General:</value>
+  </data>
+  <data name="TeslaMate:" xml:space="preserve">
+    <value>TeslaMate:</value>
+  </data>
+  <data name="Home Geofence" xml:space="preserve">
+    <value>Home Geofence</value>
+  </data>
+  <data name="To update the location, click the save button on the bottom of the page" xml:space="preserve">
+    <value>To update the location, click the save button on the bottom of the page</value>
+  </data>
+  <data name="Click on the map to select your home geofence. Within that area TSC will regulate the charging power." xml:space="preserve">
+    <value>Click on the map to select your home geofence. Within that area TSC will regulate the charging power.</value>
+  </data>
+  <data name="Telegram:" xml:space="preserve">
+    <value>Telegram:</value>
+  </data>
+  <data name="How to set up Telegram" xml:space="preserve">
+    <value>How to set up Telegram</value>
+  </data>
+  <data name="Note: The Telegram bot for now only sends messages if something is not working. E.g. The car does not respond to commands, solar power values can not be refreshed,..." xml:space="preserve">
+    <value>Note: The Telegram bot for now only sends messages if something is not working. E.g. The car does not respond to commands, solar power values can not be refreshed,...</value>
+  </data>
+  <data name="Send test message" xml:space="preserve">
+    <value>Send test message</value>
+  </data>
+  <data name="You need to save the configuration before testing it." xml:space="preserve">
+    <value>You need to save the configuration before testing it.</value>
+  </data>
+  <data name="Advanced settings. Please only change values here if you know what you are doing." xml:space="preserve">
+    <value>Advanced settings. Please only change values here if you know what you are doing.</value>
+  </data>
+  <data name="Values blelow 25 seconds are not recommended and might cause performance issues." xml:space="preserve">
+    <value>Values blelow 25 seconds are not recommended and might cause performance issues.</value>
+  </data>
+  <data name="Saved." xml:space="preserve">
+    <value>Saved.</value>
+  </data>
+  <data name="Could not get result" xml:space="preserve">
+    <value>Could not get result</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- localize the BaseConfiguration page strings through IStringLocalizer
- add English and German resource files for the BaseConfiguration page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb8adaae948324a0c178e15128eb69