### PR TITLE
Add localization for charge cost detail page

### DIFF
--- a/TeslaSolarCharger/Client/Pages/ChargeCostDetail.razor
+++ b/TeslaSolarCharger/Client/Pages/ChargeCostDetail.razor
@@ -1,5 +1,6 @@
-﻿@page "/ChargePrice/detail/{chargeCostId:int}"
+@page "/ChargePrice/detail/{chargeCostId:int}"
 @page "/ChargePrice/new"
+@using Microsoft.Extensions.Localization
 @using TeslaSolarCharger.Shared.Dtos.ChargingCost
 @using TeslaSolarCharger.Shared.Contracts
 @using TeslaSolarCharger.Shared.Dtos.ChargingCost.CostConfigurations
@@ -13,9 +14,10 @@
 @inject IDateTimeProvider DateTimeProvider
 @inject ISnackbar Snackbar
 @inject IChargePriceService ChargePriceService
+@inject IStringLocalizer<ChargeCostDetail> Localizer
 
-<button class="btn btn-primary" @onclick="NavigateToList">All Charge costs</button>
-<h1>ChargePriceDetail</h1>
+<button class="btn btn-primary" @onclick="NavigateToList">@Localizer["All Charge costs"]</button>
+<h1>@Localizer["Charge price detail"]</h1>
 
 @if (ChargePrice == null)
 {
@@ -27,7 +29,7 @@ else
         <DataAnnotationsValidator />
         <ValidationSummary />
         <InputComponent ValueId="chargePriceId"
-                        LabelText="ID"
+                        LabelText='@Localizer["ID"]"
                         UnitText=""
                         HelpText="">
             <InputFragment>
@@ -36,7 +38,7 @@ else
         </InputComponent>
 
         <InputComponent ValueId="date"
-                        LabelText="Valid Since"
+                        LabelText='@Localizer["Valid Since"]"
                         UnitText=""
                         HelpText="">
             <InputFragment>
@@ -45,7 +47,7 @@ else
         </InputComponent>
 
         <InputComponent ValueId="solarPrice"
-                        LabelText="Solar Price"
+                        LabelText='@Localizer["Solar Price"]"
                         UnitText=""
                         HelpText="">
             <InputFragment>
@@ -54,19 +56,19 @@ else
         </InputComponent>
         
         <InputComponent ValueId="energyProvider"
-                        LabelText="Energy Provider"
+                        LabelText='@Localizer["Energy Provider"]"
                         UnitText=""
                         HelpText="">
             <InputFragment>
                 <InputSelect id="energyProvider" Value="ChargePrice.EnergyProvider" ValueExpression="() => ChargePrice.EnergyProvider" ValueChanged="@((EnergyProvider e) => EnergyProviderChanged(e))" class="form-control">
-                    <option value="@EnergyProvider.OldTeslaSolarChargerConfig">Fixed Price or Spot price</option>
-                    <option value="@EnergyProvider.FixedPrice">Time based prices</option>
+                    <option value="@EnergyProvider.OldTeslaSolarChargerConfig">@Localizer["Fixed Price or Spot price"]</option>
+                    <option value="@EnergyProvider.FixedPrice">@Localizer["Time based prices"]</option>
                 </InputSelect>
             </InputFragment>
         </InputComponent>
 
         <InputComponent ValueId="gridPrice"
-                        LabelText="@(ChargePrice.AddSpotPriceToGridPrice ? "Base Price (Spot price will be added to this price)" : "Grid Price")"
+                        LabelText='@(ChargePrice.AddSpotPriceToGridPrice ? Localizer["Base Price (Spot price will be added to this price)"] : Localizer["Grid Price"])'
                         UnitText=""
                         HelpText="">
             <InputFragment>
@@ -76,7 +78,7 @@ else
 
         @if (ChargePrice.EnergyProvider == EnergyProvider.FixedPrice && FixedPrices != null)
         {
-            <div>You can specify times with special prices here. If there are times left, you didn't specify a price for, the default grid price, specified above, is used.</div>
+            <div>@Localizer["You can specify times with special prices here. If there are times left, you didn't specify a price for, the default grid price, specified above, is used."]</div>
             @foreach (var fixedPrice in FixedPrices)
             {
                 <div class="row mt-3">
@@ -88,7 +90,7 @@ else
                 <div class="row mt-3">
                     <div class="col-auto">
                         <InputComponent ValueId="price"
-                                        LabelText="Price"
+                                        LabelText='@Localizer["Price"]"
                                         UnitText=""
                                         HelpText="">
                             <InputFragment>
@@ -103,7 +105,7 @@ else
                 
                 <hr/>
             }
-            <button type="button" class="btn btn-primary m-2" @onclick="AddFixedPrice">Add time based price</button>
+            <button type="button" class="btn btn-primary m-2" @onclick="AddFixedPrice">@Localizer["Add time based price"]</button>
         }
         
         @if (ChargePrice.EnergyProvider == EnergyProvider.OldTeslaSolarChargerConfig)
@@ -111,18 +113,18 @@ else
             <div class="mb-3">
                 <InputCheckbox class="form-check-input" id="useSpotPrice1" @bind-Value="ChargePrice.AddSpotPriceToGridPrice" />
                 <label class="form-check-label" for="useSpotPrice1">
-                    Use Spot Prices
+                    @Localizer["Use Spot Prices"]
                 </label>
                 <div>
-                    <small id="UseSpotPriceHelp" class="form-text text-muted">Enable this if you are using dynamic prices based on EPEX Spot DE (e.g. Tibber or aWATTar)</small>
+                    <small id="UseSpotPriceHelp" class="form-text text-muted">@Localizer["Enable this if you are using dynamic prices based on EPEX Spot DE (e.g. Tibber or aWATTar)"]</small>
                 </div>
             </div>
             @if (ChargePrice.AddSpotPriceToGridPrice)
             {
                 <InputComponent ValueId="chargePriceSurcharge"
-                                LabelText="Additional costs to spotprice"
+                                LabelText='@Localizer["Additional costs to spotprice"]"
                                 UnitText="%"
-                                HelpText="Surcharge to spot price (e.g. aWATTar 3% + 19% VAT in Germany). Note: Spot prices are without VAT.">
+                                HelpText='@Localizer["Surcharge to spot price (e.g. aWATTar 3% + 19% VAT in Germany). Note: Spot prices are without VAT."]">
                     <InputFragment>
                         <InputNumber id="chargePriceSurcharge" @bind-Value="ChargePrice.SpotPriceSurcharge" class="form-control" placeholder=" " />
                     </InputFragment>
@@ -146,14 +148,14 @@ else
         {
             <MudPaper Class="d-flex justify-end flex-grow-1 gap-4 pr-2 mb-2" Elevation="0">
                 <MudAlert Severity="Severity.Info">
-                    Updating charge prices can take a significant amount of time as the prices of all previous charges are updated
+                    @Localizer["Updating charge prices can take a significant amount of time as the prices of all previous charges are updated"]
                 </MudAlert>
             </MudPaper>
         }
         
         <RightAlignedButtonComponent ButtonType="ButtonType.Submit"
                                      IsLoading="@(SubmitIsLoading || ChargePriceUpdateProgress != default)"
-                                     ButtonText="Save"/>
+                                     ButtonText='@Localizer["Save"]"/>
     </EditForm>
 }
 
@@ -208,7 +210,7 @@ else
     {
         if(ChargePrice == null)
         {
-            Snackbar.Add("Charge price is null and can not be saved. Try reloading the page.", Severity.Error);
+            Snackbar.Add(Localizer["Charge price is null and can not be saved. Try reloading the page."], Severity.Error);
             return;
         }
         SubmitIsLoading = true;

--- a/TeslaSolarCharger/Client/Resources/Pages/ChargeCostDetail.de.resx
+++ b/TeslaSolarCharger/Client/Resources/Pages/ChargeCostDetail.de.resx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+  <data name="All Charge costs" xml:space="preserve">
+    <value>Alle Ladekosten</value>
+  </data>
+  <data name="Charge price detail" xml:space="preserve">
+    <value>Details zum Ladetarif</value>
+  </data>
+  <data name="ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Valid Since" xml:space="preserve">
+    <value>Gültig seit</value>
+  </data>
+  <data name="Solar Price" xml:space="preserve">
+    <value>Solarpreis</value>
+  </data>
+  <data name="Energy Provider" xml:space="preserve">
+    <value>Energieversorger</value>
+  </data>
+  <data name="Fixed Price or Spot price" xml:space="preserve">
+    <value>Fixpreis oder Spotpreis</value>
+  </data>
+  <data name="Time based prices" xml:space="preserve">
+    <value>Zeitbasierte Preise</value>
+  </data>
+  <data name="Base Price (Spot price will be added to this price)" xml:space="preserve">
+    <value>Grundpreis (Spotpreis wird zu diesem Preis hinzugefügt)</value>
+  </data>
+  <data name="Grid Price" xml:space="preserve">
+    <value>Netzpreis</value>
+  </data>
+  <data name="You can specify times with special prices here. If there are times left, you didn't specify a price for, the default grid price, specified above, is used." xml:space="preserve">
+    <value>Hier können Zeiten mit speziellen Preisen festgelegt werden. Für alle übrigen Zeiten gilt der oben angegebene Standardnetzpreis.</value>
+  </data>
+  <data name="Price" xml:space="preserve">
+    <value>Preis</value>
+  </data>
+  <data name="Add time based price" xml:space="preserve">
+    <value>Zeitbasierten Preis hinzufügen</value>
+  </data>
+  <data name="Use Spot Prices" xml:space="preserve">
+    <value>Spotpreise verwenden</value>
+  </data>
+  <data name="Enable this if you are using dynamic prices based on EPEX Spot DE (e.g. Tibber or aWATTar)" xml:space="preserve">
+    <value>Aktivieren Sie dies, wenn Sie dynamische Preise auf Basis der EPEX Spot DE verwenden (z. B. Tibber oder aWATTar)</value>
+  </data>
+  <data name="Additional costs to spotprice" xml:space="preserve">
+    <value>Zusätzliche Kosten zum Spotpreis</value>
+  </data>
+  <data name="Surcharge to spot price (e.g. aWATTar 3% + 19% VAT in Germany). Note: Spot prices are without VAT." xml:space="preserve">
+    <value>Aufschlag auf den Spotpreis (z. B. aWATTar 3 % + 19 % MwSt. in Deutschland). Hinweis: Spotpreise sind ohne MwSt.</value>
+  </data>
+  <data name="Updating charge prices can take a significant amount of time as the prices of all previous charges are updated" xml:space="preserve">
+    <value>Das Aktualisieren der Ladetarife kann einige Zeit dauern, da alle bisherigen Ladevorgänge neu berechnet werden.</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
+  <data name="Charge price is null and can not be saved. Try reloading the page." xml:space="preserve">
+    <value>Der Ladetarif ist leer und kann nicht gespeichert werden. Bitte laden Sie die Seite neu.</value>
+  </data>
+</root>

--- a/TeslaSolarCharger/Client/Resources/Pages/ChargeCostDetail.en.resx
+++ b/TeslaSolarCharger/Client/Resources/Pages/ChargeCostDetail.en.resx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+  <data name="All Charge costs" xml:space="preserve">
+    <value>All Charge costs</value>
+  </data>
+  <data name="Charge price detail" xml:space="preserve">
+    <value>Charge price detail</value>
+  </data>
+  <data name="ID" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="Valid Since" xml:space="preserve">
+    <value>Valid Since</value>
+  </data>
+  <data name="Solar Price" xml:space="preserve">
+    <value>Solar Price</value>
+  </data>
+  <data name="Energy Provider" xml:space="preserve">
+    <value>Energy Provider</value>
+  </data>
+  <data name="Fixed Price or Spot price" xml:space="preserve">
+    <value>Fixed Price or Spot price</value>
+  </data>
+  <data name="Time based prices" xml:space="preserve">
+    <value>Time based prices</value>
+  </data>
+  <data name="Base Price (Spot price will be added to this price)" xml:space="preserve">
+    <value>Base Price (Spot price will be added to this price)</value>
+  </data>
+  <data name="Grid Price" xml:space="preserve">
+    <value>Grid Price</value>
+  </data>
+  <data name="You can specify times with special prices here. If there are times left, you didn't specify a price for, the default grid price, specified above, is used." xml:space="preserve">
+    <value>You can specify times with special prices here. If there are times left, you didn't specify a price for, the default grid price, specified above, is used.</value>
+  </data>
+  <data name="Price" xml:space="preserve">
+    <value>Price</value>
+  </data>
+  <data name="Add time based price" xml:space="preserve">
+    <value>Add time based price</value>
+  </data>
+  <data name="Use Spot Prices" xml:space="preserve">
+    <value>Use Spot Prices</value>
+  </data>
+  <data name="Enable this if you are using dynamic prices based on EPEX Spot DE (e.g. Tibber or aWATTar)" xml:space="preserve">
+    <value>Enable this if you are using dynamic prices based on EPEX Spot DE (e.g. Tibber or aWATTar)</value>
+  </data>
+  <data name="Additional costs to spotprice" xml:space="preserve">
+    <value>Additional costs to spotprice</value>
+  </data>
+  <data name="Surcharge to spot price (e.g. aWATTar 3% + 19% VAT in Germany). Note: Spot prices are without VAT." xml:space="preserve">
+    <value>Surcharge to spot price (e.g. aWATTar 3% + 19% VAT in Germany). Note: Spot prices are without VAT.</value>
+  </data>
+  <data name="Updating charge prices can take a significant amount of time as the prices of all previous charges are updated" xml:space="preserve">
+    <value>Updating charge prices can take a significant amount of time as the prices of all previous charges are updated</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Charge price is null and can not be saved. Try reloading the page." xml:space="preserve">
+    <value>Charge price is null and can not be saved. Try reloading the page.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add string localizer support to the charge cost detail page and replace hard-coded UI text with localized strings
- provide English and German resource files for the charge cost detail page content

## Testing
- dotnet build TeslaSolarCharger.sln *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb8af4f53483249513f9348d735770