### PR TITLE
Add resource-backed metadata for base configuration UI labels

### DIFF
--- a/TeslaSolarCharger/Client/Components/GenericInput.razor
+++ b/TeslaSolarCharger/Client/Components/GenericInput.razor
@@ -844,8 +844,8 @@
             throw new ArgumentException($"Expression '{For}' refers to a field, not a property.");
         }
 
-        //Only set label name based on property  name / display name attribute if not already set via parameter
-        LabelName ??= propertyInfo.GetCustomAttributes<DisplayNameAttribute>(false).SingleOrDefault()?.DisplayName ?? StringHelper.GenerateFriendlyStringWithOutIdSuffix(propertyInfo.Name);
+        //Only set label name based on property name / display name attribute if not already set via parameter
+        LabelName ??= StringHelper.GetDisplayNameFor(For!);
 
         IsRequired = IsRequiredParameter ?? propertyInfo.GetCustomAttributes(true).OfType<RequiredAttribute>().Any();
         if (IsReadOnlyParameter == true)
@@ -858,8 +858,8 @@
             IsDisabled = IsDisabledParameter ?? propertyInfo.GetCustomAttributes(true).OfType<DisabledAttribute>().Any();
         }
 
-        var helperText = propertyInfo.GetCustomAttributes<HelperTextAttribute>(false).SingleOrDefault()?.HelperText;
-        if (helperText != default)
+        var helperText = StringHelper.GetHelperTextFor(For!);
+        if (!string.IsNullOrWhiteSpace(helperText))
         {
             HelperText = helperText;
         }

--- a/TeslaSolarCharger/Shared/Attributes/HelperTextAttribute.cs
+++ b/TeslaSolarCharger/Shared/Attributes/HelperTextAttribute.cs
@@ -1,16 +1,53 @@
-﻿namespace TeslaSolarCharger.Shared.Attributes;
+using System;
+using System.Reflection;
+using System.Resources;
+
+namespace TeslaSolarCharger.Shared.Attributes;
 
 public class HelperTextAttribute : Attribute
 {
-    public string HelperText { get; set; }
+    private readonly string? helperText;
+    private readonly Type? resourceType;
+    private readonly string? resourceName;
 
     public HelperTextAttribute()
     {
-        HelperText = string.Empty;
+        helperText = string.Empty;
     }
 
     public HelperTextAttribute(string helperText)
     {
-        HelperText = helperText;
+        this.helperText = helperText;
+    }
+
+    public HelperTextAttribute(Type resourceType, string resourceName)
+    {
+        this.resourceType = resourceType ?? throw new ArgumentNullException(nameof(resourceType));
+        this.resourceName = resourceName ?? throw new ArgumentNullException(nameof(resourceName));
+    }
+
+    public string HelperText => resourceType == null
+        ? helperText ?? string.Empty
+        : LookupResourceValue(resourceType, resourceName!);
+
+    private static string LookupResourceValue(Type resourceType, string resourceKey)
+    {
+        var property = resourceType.GetProperty(resourceKey, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property?.PropertyType == typeof(string) && property.GetValue(null, null) is string propertyValue)
+        {
+            return propertyValue;
+        }
+
+        var resourceManagerProperty = resourceType.GetProperty("ResourceManager", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        if (resourceManagerProperty?.GetValue(null, null) is ResourceManager resourceManager)
+        {
+            var resourceValue = resourceManager.GetString(resourceKey);
+            if (resourceValue != null)
+            {
+                return resourceValue;
+            }
+        }
+
+        return resourceKey;
     }
 }

--- a/TeslaSolarCharger/Shared/Attributes/LocalizedDisplayNameAttribute.cs
+++ b/TeslaSolarCharger/Shared/Attributes/LocalizedDisplayNameAttribute.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Resources;
+
+namespace TeslaSolarCharger.Shared.Attributes;
+
+public sealed class LocalizedDisplayNameAttribute : DisplayNameAttribute
+{
+    private readonly Type resourceType;
+    private readonly string resourceName;
+
+    public LocalizedDisplayNameAttribute(Type resourceType, string resourceName)
+        : base(resourceName)
+    {
+        this.resourceType = resourceType ?? throw new ArgumentNullException(nameof(resourceType));
+        this.resourceName = resourceName ?? throw new ArgumentNullException(nameof(resourceName));
+    }
+
+    public override string DisplayName => LookupResourceValue(resourceType, resourceName) ?? base.DisplayName;
+
+    private static string? LookupResourceValue(Type resourceType, string resourceName)
+    {
+        var property = resourceType.GetProperty(resourceName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property?.PropertyType == typeof(string))
+        {
+            return property.GetValue(null, null) as string;
+        }
+
+        var resourceManagerProperty = resourceType.GetProperty("ResourceManager", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+        if (resourceManagerProperty?.GetValue(null, null) is ResourceManager resourceManager)
+        {
+            return resourceManager.GetString(resourceName);
+        }
+
+        return null;
+    }
+}

--- a/TeslaSolarCharger/Shared/Dtos/BaseConfiguration/BaseConfigurationBase.cs
+++ b/TeslaSolarCharger/Shared/Dtos/BaseConfiguration/BaseConfigurationBase.cs
@@ -1,6 +1,7 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using TeslaSolarCharger.Shared.Attributes;
+using TeslaSolarCharger.Shared.Resources.BaseConfiguration;
 
 namespace TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
 
@@ -19,8 +20,8 @@ public class BaseConfigurationBase
     public Dictionary<string, string> HomeBatterySocHeaders { get; set; } = new();
     public string? HomeBatteryPowerMqttTopic { get; set; }
     public string? HomeBatteryPowerUrl { get; set; }
-    [DisplayName("HomeBatteryPowerInversion Url")]
-    [HelperText("Use this if you have to dynamically invert the home battery power. Note: Only 0 and 1 are allowed as response. As far as I know this is only needed with Sungrow Inverters.")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryPowerInversionUrl_DisplayName))]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryPowerInversionUrl_HelperText))]
     public string? HomeBatteryPowerInversionUrl { get; set; }
     public Dictionary<string, string> HomeBatteryPowerHeaders { get; set; } = new();
     public Dictionary<string, string> HomeBatteryPowerInversionHeaders { get; set; } = new();
@@ -32,17 +33,17 @@ public class BaseConfigurationBase
     public Dictionary<string, string> CurrentInverterPowerHeaders { get; set; } = new();
     public bool IsModbusCurrentInverterPowerUrl { get; set; }
     [Required]
-    [DisplayName("Power Change Interval")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UpdateIntervalSeconds_DisplayName))]
     [Postfix("s")]
-    [HelperText("Every x seconds it is checked if any power changes are required.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UpdateIntervalSeconds_HelperText))]
     public int UpdateIntervalSeconds { get; set; } = 30;
     [Required]
     [Postfix("s")]
-    [HelperText("Be cautious when setting values below 25 seconds as this might result in unexpected bahaviour as cars or charging stations might take some time to update the power.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.SkipPowerChangesOnLastAdjustmentNewerThanSeconds_HelperText))]
     public int SkipPowerChangesOnLastAdjustmentNewerThanSeconds { get; set; } = 25;
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Solar power refresh interval")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.PvValueUpdateIntervalSeconds_DisplayName))]
     [Postfix("s")]
     public int? PvValueUpdateIntervalSeconds { get; set; } = 1;
     [Required]
@@ -53,26 +54,26 @@ public class BaseConfigurationBase
     public string GeoFence { get; set; } = "Home";
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Time with enough solar power until charging starts")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MinutesUntilSwitchOn_DisplayName))]
     [Postfix("min")]
     public int MinutesUntilSwitchOn { get; set; } = 5;
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Time without enough solar power until charging stops")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MinutesUntilSwitchOff_DisplayName))]
     [Postfix("min")]
     public int MinutesUntilSwitchOff { get; set; } = 5;
     [Required]
-    [DisplayName("Power Buffer")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.PowerBuffer_DisplayName))]
     [Postfix("W")]
-    [HelperText("Set values higher than 0 to always have some overage (power to grid). Set values lower than 0 to always consume some power from the grid.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.PowerBuffer_HelperText))]
     public int PowerBuffer { get; set; } = 0;
-    [HelperText("If enabled, the configured power buffer is displayed on the home screen, including the option to directly change it.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.AllowPowerBufferChangeOnHome_HelperText))]
     public bool AllowPowerBufferChangeOnHome { get; set; }
-    [HelperText("If enabled, your home geofence location is transfered to the Solar4Car.com servers as well as to the servers of www.visualcrossing.com. At no point will your location data be linked with other data.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.PredictSolarPowerGeneration_HelperText))]
     public bool PredictSolarPowerGeneration { get; set; }
-    [HelperText("If enabled, when a target Soc is set not only grid prices but also estimated solar power generation is used to schedule charging.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UsePredictedSolarPowerGenerationForChargingSchedules_HelperText))]
     public bool UsePredictedSolarPowerGenerationForChargingSchedules { get; set; }
-    [HelperText("This is in an early beta and might not behave like expected. Loading might take longer than 30 seconds or never load on low performance devices like Raspery Pi 3. This will be fixed in a future update.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.ShowEnergyDataOnHome_HelperText))]
     public bool ShowEnergyDataOnHome { get; set; }
     public string? CurrentPowerToGridJsonPattern { get; set; }
     public decimal CurrentPowerToGridCorrectionFactor { get; set; } = 1;

--- a/TeslaSolarCharger/Shared/Helper/Contracts/IStringHelper.cs
+++ b/TeslaSolarCharger/Shared/Helper/Contracts/IStringHelper.cs
@@ -1,8 +1,12 @@
-﻿namespace TeslaSolarCharger.Shared.Helper.Contracts;
+using System.Linq.Expressions;
+
+namespace TeslaSolarCharger.Shared.Helper.Contracts;
 
 public interface IStringHelper
 {
     string MakeNonWhiteSpaceCapitalString(string inputString);
     string GenerateFriendlyStringWithOutIdSuffix(string inputString);
     string GenerateFriendlyStringFromPascalString(string inputString);
+    string GetDisplayNameFor(LambdaExpression propertyExpression);
+    string? GetHelperTextFor(LambdaExpression propertyExpression);
 }

--- a/TeslaSolarCharger/Shared/Helper/StringHelper.cs
+++ b/TeslaSolarCharger/Shared/Helper/StringHelper.cs
@@ -1,5 +1,10 @@
-﻿using Microsoft.Extensions.Logging;
+using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reflection;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using TeslaSolarCharger.Shared.Attributes;
 using TeslaSolarCharger.Shared.Helper.Contracts;
 
 namespace TeslaSolarCharger.Shared.Helper;
@@ -33,5 +38,48 @@ public class StringHelper(ILogger<StringHelper> logger) : IStringHelper
     public string GenerateFriendlyStringFromPascalString(string inputString)
     {
         return Regex.Replace(inputString, "(\\B[A-Z])", " $1");
+    }
+
+    public string GetDisplayNameFor(LambdaExpression propertyExpression)
+    {
+        ArgumentNullException.ThrowIfNull(propertyExpression);
+        logger.LogTrace("{method}({expression})", nameof(GetDisplayNameFor), propertyExpression);
+        var propertyInfo = GetPropertyInfo(propertyExpression);
+        var displayNameAttribute = propertyInfo.GetCustomAttribute<DisplayNameAttribute>();
+        if (displayNameAttribute != null && !string.IsNullOrWhiteSpace(displayNameAttribute.DisplayName))
+        {
+            return displayNameAttribute.DisplayName;
+        }
+
+        return GenerateFriendlyStringWithOutIdSuffix(propertyInfo.Name);
+    }
+
+    public string? GetHelperTextFor(LambdaExpression propertyExpression)
+    {
+        ArgumentNullException.ThrowIfNull(propertyExpression);
+        logger.LogTrace("{method}({expression})", nameof(GetHelperTextFor), propertyExpression);
+        var propertyInfo = GetPropertyInfo(propertyExpression);
+        return propertyInfo.GetCustomAttribute<HelperTextAttribute>()?.HelperText;
+    }
+
+    private static PropertyInfo GetPropertyInfo(LambdaExpression propertyExpression)
+    {
+        Expression body = propertyExpression.Body;
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked, Operand: MemberExpression unaryMember })
+        {
+            body = unaryMember;
+        }
+
+        if (body is not MemberExpression memberExpression)
+        {
+            throw new ArgumentException("Expression must target a property", nameof(propertyExpression));
+        }
+
+        if (memberExpression.Member is not PropertyInfo propertyInfo)
+        {
+            throw new ArgumentException("Expression must target a property", nameof(propertyExpression));
+        }
+
+        return propertyInfo;
     }
 }

--- a/TeslaSolarCharger/Shared/Resources/BaseConfiguration/BaseConfigurationTexts.de.resx
+++ b/TeslaSolarCharger/Shared/Resources/BaseConfiguration/BaseConfigurationTexts.de.resx
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="HomeBatteryPowerInversionUrl_DisplayName" xml:space="preserve">
+    <value>HomeBatteryPowerInversion-URL</value>
+  </data>
+  <data name="HomeBatteryPowerInversionUrl_HelperText" xml:space="preserve">
+    <value>Verwenden Sie diese Option, wenn die Leistung des Hausspeichers dynamisch invertiert werden muss. Hinweis: Als Antwort sind nur 0 und 1 erlaubt. Soweit bekannt, wird dies nur bei Sungrow-Wechselrichtern benötigt.</value>
+  </data>
+  <data name="UpdateIntervalSeconds_DisplayName" xml:space="preserve">
+    <value>Intervall für Leistungsänderungen</value>
+  </data>
+  <data name="UpdateIntervalSeconds_HelperText" xml:space="preserve">
+    <value>In diesem Intervall wird geprüft, ob Leistungsanpassungen notwendig sind.</value>
+  </data>
+  <data name="SkipPowerChangesOnLastAdjustmentNewerThanSeconds_HelperText" xml:space="preserve">
+    <value>Werte unter 25 Sekunden können zu unerwartetem Verhalten führen, da Fahrzeuge oder Wallboxen etwas Zeit für die Leistungsanpassung benötigen.</value>
+  </data>
+  <data name="PvValueUpdateIntervalSeconds_DisplayName" xml:space="preserve">
+    <value>Aktualisierungsintervall Solarleistung</value>
+  </data>
+  <data name="MinutesUntilSwitchOn_DisplayName" xml:space="preserve">
+    <value>Zeit mit genügend Solarleistung bis zum Start</value>
+  </data>
+  <data name="MinutesUntilSwitchOff_DisplayName" xml:space="preserve">
+    <value>Zeit ohne genügend Solarleistung bis zum Stopp</value>
+  </data>
+  <data name="PowerBuffer_DisplayName" xml:space="preserve">
+    <value>Leistungspuffer</value>
+  </data>
+  <data name="PowerBuffer_HelperText" xml:space="preserve">
+    <value>Werte über 0 sorgen für eine Einspeisung ins Netz. Werte unter 0 bewirken einen konstanten Netzbezug.</value>
+  </data>
+  <data name="AllowPowerBufferChangeOnHome_HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, wird der konfigurierte Leistungspuffer auf der Startseite angezeigt und kann dort direkt angepasst werden.</value>
+  </data>
+  <data name="PredictSolarPowerGeneration_HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, wird Ihr Geofence-Standort sowohl an die Server von Solar4Car.com als auch an www.visualcrossing.com übertragen. Die Standortdaten werden niemals mit anderen Daten verknüpft.</value>
+  </data>
+  <data name="UsePredictedSolarPowerGenerationForChargingSchedules_HelperText" xml:space="preserve">
+    <value>Wenn ein Ziel-SoC gesetzt ist, werden neben den Netzpreisen auch geschätzte PV-Erträge zur Ladeplanung verwendet.</value>
+  </data>
+  <data name="ShowEnergyDataOnHome_HelperText" xml:space="preserve">
+    <value>Diese Funktion befindet sich in einer frühen Beta und kann sich unerwartet verhalten. Das Laden kann länger als 30 Sekunden dauern oder auf schwacher Hardware (z. B. Raspberry Pi 3) scheitern.</value>
+  </data>
+</root>

--- a/TeslaSolarCharger/Shared/Resources/BaseConfiguration/BaseConfigurationTexts.resx
+++ b/TeslaSolarCharger/Shared/Resources/BaseConfiguration/BaseConfigurationTexts.resx
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="HomeBatteryPowerInversionUrl_DisplayName" xml:space="preserve">
+    <value>HomeBatteryPowerInversion Url</value>
+  </data>
+  <data name="HomeBatteryPowerInversionUrl_HelperText" xml:space="preserve">
+    <value>Use this if you have to dynamically invert the home battery power. Note: Only 0 and 1 are allowed as response. As far as I know this is only needed with Sungrow Inverters.</value>
+  </data>
+  <data name="UpdateIntervalSeconds_DisplayName" xml:space="preserve">
+    <value>Power Change Interval</value>
+  </data>
+  <data name="UpdateIntervalSeconds_HelperText" xml:space="preserve">
+    <value>Every x seconds it is checked if any power changes are required.</value>
+  </data>
+  <data name="SkipPowerChangesOnLastAdjustmentNewerThanSeconds_HelperText" xml:space="preserve">
+    <value>Be cautious when setting values below 25 seconds as this might result in unexpected behaviour as cars or charging stations might take some time to update the power.</value>
+  </data>
+  <data name="PvValueUpdateIntervalSeconds_DisplayName" xml:space="preserve">
+    <value>Solar power refresh interval</value>
+  </data>
+  <data name="MinutesUntilSwitchOn_DisplayName" xml:space="preserve">
+    <value>Time with enough solar power until charging starts</value>
+  </data>
+  <data name="MinutesUntilSwitchOff_DisplayName" xml:space="preserve">
+    <value>Time without enough solar power until charging stops</value>
+  </data>
+  <data name="PowerBuffer_DisplayName" xml:space="preserve">
+    <value>Power Buffer</value>
+  </data>
+  <data name="PowerBuffer_HelperText" xml:space="preserve">
+    <value>Set values higher than 0 to always have some overage (power to grid). Set values lower than 0 to always consume some power from the grid.</value>
+  </data>
+  <data name="AllowPowerBufferChangeOnHome_HelperText" xml:space="preserve">
+    <value>If enabled, the configured power buffer is displayed on the home screen, including the option to directly change it.</value>
+  </data>
+  <data name="PredictSolarPowerGeneration_HelperText" xml:space="preserve">
+    <value>If enabled, your home geofence location is transferred to the Solar4Car.com servers as well as to the servers of www.visualcrossing.com. At no point will your location data be linked with other data.</value>
+  </data>
+  <data name="UsePredictedSolarPowerGenerationForChargingSchedules_HelperText" xml:space="preserve">
+    <value>If enabled, when a target SoC is set not only grid prices but also estimated solar power generation is used to schedule charging.</value>
+  </data>
+  <data name="ShowEnergyDataOnHome_HelperText" xml:space="preserve">
+    <value>This is in an early beta and might not behave like expected. Loading might take longer than 30 seconds or never load on low performance devices like Raspberry Pi 3. This will be fixed in a future update.</value>
+  </data>
+</root>

--- a/TeslaSolarCharger/Shared/TeslaSolarCharger.Shared.csproj
+++ b/TeslaSolarCharger/Shared/TeslaSolarCharger.Shared.csproj
@@ -30,6 +30,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Resources\BaseConfiguration\BaseConfigurationTexts.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>BaseConfigurationTexts.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>TeslaSolarCharger.Shared.Resources.BaseConfiguration</CustomToolNamespace>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\BaseConfiguration\BaseConfigurationTexts.de.resx">
+      <DependentUpon>BaseConfigurationTexts.resx</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\TeslaSolarCharger.SharedModel\TeslaSolarCharger.SharedModel.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- introduce `LocalizedDisplayNameAttribute` and extend `HelperTextAttribute` to resolve strings from resource files
- add English and German base-configuration resource files and wire them into the shared project
- consume the localized metadata in `BaseConfigurationBase` and `GenericInput` via new `IStringHelper` helpers

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68eb9d94bb64832492831c8dd74b2c86