### PR TITLE
Add shared localization infrastructure

### DIFF
--- a/TeslaSolarCharger/Client/Components/GenericInput.razor
+++ b/TeslaSolarCharger/Client/Components/GenericInput.razor
@@ -4,11 +4,13 @@
 @using System.ComponentModel
 @using MudExtensions
 @using TeslaSolarCharger.Shared.Attributes
+@using TeslaSolarCharger.Shared.Localization
 @using TeslaSolarCharger.Shared.Helper.Contracts
 @using TeslaSolarCharger.Shared.Resources.Contracts
 
 @inject IConstants Constants
 @inject IStringHelper StringHelper
+@inject IAppStringLocalizer AppStringLocalizer
 
 @typeparam T
 
@@ -520,13 +522,13 @@
             var displayAttribute = memberInfo.GetCustomAttribute<DisplayAttribute>();
             if (displayAttribute != null && !string.IsNullOrEmpty(displayAttribute.Name))
             {
-                return displayAttribute.Name;
+                return AppStringLocalizer[displayAttribute.Name];
             }
 
             var descriptionAttribute = memberInfo.GetCustomAttribute<DescriptionAttribute>();
             if (descriptionAttribute != null && !string.IsNullOrEmpty(descriptionAttribute.Description))
             {
-                return descriptionAttribute.Description;
+                return AppStringLocalizer[descriptionAttribute.Description];
             }
         }
         var friendlyName = StringHelper.GenerateFriendlyStringWithOutIdSuffix(enumMemberName);
@@ -844,8 +846,26 @@
             throw new ArgumentException($"Expression '{For}' refers to a field, not a property.");
         }
 
-        //Only set label name based on property  name / display name attribute if not already set via parameter
-        LabelName ??= propertyInfo.GetCustomAttributes<DisplayNameAttribute>(false).SingleOrDefault()?.DisplayName ?? StringHelper.GenerateFriendlyStringWithOutIdSuffix(propertyInfo.Name);
+        if (LabelName == null)
+        {
+            var displayNameAttribute = propertyInfo.GetCustomAttributes<DisplayNameAttribute>(false).SingleOrDefault();
+            if (displayNameAttribute != null && !string.IsNullOrWhiteSpace(displayNameAttribute.DisplayName))
+            {
+                LabelName = AppStringLocalizer[displayNameAttribute.DisplayName];
+            }
+            else
+            {
+                var displayAttribute = propertyInfo.GetCustomAttributes<DisplayAttribute>(false).SingleOrDefault();
+                if (displayAttribute != null && !string.IsNullOrWhiteSpace(displayAttribute.Name))
+                {
+                    LabelName = AppStringLocalizer[displayAttribute.Name];
+                }
+                else
+                {
+                    LabelName = StringHelper.GenerateFriendlyStringWithOutIdSuffix(propertyInfo.Name);
+                }
+            }
+        }
 
         IsRequired = IsRequiredParameter ?? propertyInfo.GetCustomAttributes(true).OfType<RequiredAttribute>().Any();
         if (IsReadOnlyParameter == true)
@@ -858,10 +878,10 @@
             IsDisabled = IsDisabledParameter ?? propertyInfo.GetCustomAttributes(true).OfType<DisabledAttribute>().Any();
         }
 
-        var helperText = propertyInfo.GetCustomAttributes<HelperTextAttribute>(false).SingleOrDefault()?.HelperText;
-        if (helperText != default)
+        var helperTextAttribute = propertyInfo.GetCustomAttributes<HelperTextAttribute>(false).SingleOrDefault();
+        if (helperTextAttribute?.HelperText != default)
         {
-            HelperText = helperText;
+            HelperText = AppStringLocalizer[helperTextAttribute.HelperText];
         }
 
 

--- a/TeslaSolarCharger/Client/Components/StartPage/NotChargingAtExpectedPowerReasonsComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/NotChargingAtExpectedPowerReasonsComponent.razor
@@ -1,11 +1,13 @@
 ﻿@using TeslaSolarCharger.Client.Services.Contracts
 @using TeslaSolarCharger.Shared.Contracts
 @using TeslaSolarCharger.Shared.Dtos.Home
+@using TeslaSolarCharger.Shared.Localization
 @using TeslaSolarCharger.Shared.SignalRClients
 @inject IHomeService HomeService
 @inject IDateTimeProvider DateTimeProvider
 @inject ILogger<NotChargingAtExpectedPowerReasonsComponent> Logger
 @inject ISignalRStateService SignalRStateService
+@inject IAppStringLocalizer AppStringLocalizer
 
 @implements IDisposable
 
@@ -27,7 +29,7 @@ else
                             if (remainingTime.HasValue)
                             {
                                 <div>
-                                    @($"{nextEndingReason.Reason}:")
+                                    @(AppStringLocalizer[LocalizationKeys.Components.NotChargingReasons.NextEndingKey, GetLocalizedReason(nextEndingReason)])
                                     <span><MudChip T="string"
                                                    Color="Color.Primary"
                                                    Size="Size.Small"
@@ -40,7 +42,7 @@ else
                         }
                         else
                         {
-                            <div>@($"{_elements.Count} reason(s) why loadpoint charges with different power than you might expect")</div>
+                            <div>@(AppStringLocalizer[LocalizationKeys.Components.NotChargingReasons.HeadingKey, _elements.Count])</div>
                         }
                     }
                     @if (_elements.Count > 0)
@@ -58,14 +60,14 @@ else
                         <li>
                             @if (element.ReasonEndTime == default)
                             {
-                                @element.Reason
+                                @GetLocalizedReason(element)
                             }
                             else
                             {
                                 var remainingTime = GetRemainingTime(element.ReasonEndTime.Value);
                                 @if (remainingTime.HasValue)
                                 {
-                                    @($"{element.Reason} (")
+                                    <span>@GetLocalizedReason(element) (</span>
                                     <span>
                                         <MudChip T="string"
                                                  Color="Color.Primary"
@@ -74,11 +76,11 @@ else
                                             @(FormatTimeSpan(remainingTime.Value))
                                         </MudChip>
                                     </span>
-                                    <span>remaining)</span>
+                                    <span>@AppStringLocalizer[LocalizationKeys.Components.NotChargingReasons.RemainingKey])</span>
                                 }
                                 else
                                 {
-                                    @(element.Reason)
+                                    @GetLocalizedReason(element)
                                 }
                             }
                         </li>
@@ -174,9 +176,21 @@ else
             .FirstOrDefault();
     }
 
-    private string FormatTimeSpan(TimeSpan timeSpan)
+    private string FormatTimeSpan(TimeSpan timeSpan) => timeSpan.ToString(@"mm\:ss");
+
+    private string GetLocalizedReason(DtoNotChargingWithExpectedPowerReason reason)
     {
-        return timeSpan.ToString(@"mm\:ss");
+        if (reason.HasResourceKey && !string.IsNullOrWhiteSpace(reason.ResourceKey))
+        {
+            if (reason.FormatParameters.Count > 0)
+            {
+                return AppStringLocalizer[reason.ResourceKey, reason.FormatParameters.ToArray()];
+            }
+
+            return AppStringLocalizer[reason.ResourceKey];
+        }
+
+        return reason.Reason ?? string.Empty;
     }
 
     public void Dispose()

--- a/TeslaSolarCharger/Server/Services/TargetChargingValueCalculationService.cs
+++ b/TeslaSolarCharger/Server/Services/TargetChargingValueCalculationService.cs
@@ -9,6 +9,7 @@ using TeslaSolarCharger.Shared.Dtos.Contracts;
 using TeslaSolarCharger.Shared.Dtos.Home;
 using TeslaSolarCharger.Shared.Dtos.Settings;
 using TeslaSolarCharger.Shared.Enums;
+using TeslaSolarCharger.Shared.Localization;
 using TeslaSolarCharger.Shared.Resources.Contracts;
 
 namespace TeslaSolarCharger.Server.Services;
@@ -85,7 +86,7 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 cancellationToken).ConfigureAwait(false);
             if (constraintValues.IsCarFullyCharged == true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId, new DtoNotChargingWithExpectedPowerReason("Car is fully charged"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId, DtoNotChargingWithExpectedPowerReason.CreateLocalized(LocalizationKeys.NotChargingReasons.CarFullyCharged));
             }
             var powerToControlIncludingHomeBatteryDischargePower = powerToControl + additionalHomeBatteryDischargePower;
             var chargingSchedulePower = chargingSchedule.TargetGridPower.HasValue && (chargingSchedule.ChargingPower < (powerToControl + (chargingSchedule.TargetGridPower ?? 0)))
@@ -114,7 +115,7 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 cancellationToken).ConfigureAwait(false);
             if (constraintValues.IsCarFullyCharged == true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId, new DtoNotChargingWithExpectedPowerReason("Car is fully charged"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId, DtoNotChargingWithExpectedPowerReason.CreateLocalized(LocalizationKeys.NotChargingReasons.CarFullyCharged));
             }
 
             var powerToControlIncludingHomeBatteryDischargePower = powerToControl;

--- a/TeslaSolarCharger/Shared/Dtos/BaseConfiguration/BaseConfigurationBase.cs
+++ b/TeslaSolarCharger/Shared/Dtos/BaseConfiguration/BaseConfigurationBase.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using TeslaSolarCharger.Shared.Attributes;
+using TeslaSolarCharger.Shared.Localization;
 
 namespace TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
 
@@ -19,8 +20,8 @@ public class BaseConfigurationBase
     public Dictionary<string, string> HomeBatterySocHeaders { get; set; } = new();
     public string? HomeBatteryPowerMqttTopic { get; set; }
     public string? HomeBatteryPowerUrl { get; set; }
-    [DisplayName("HomeBatteryPowerInversion Url")]
-    [HelperText("Use this if you have to dynamically invert the home battery power. Note: Only 0 and 1 are allowed as response. As far as I know this is only needed with Sungrow Inverters.")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.HomeBatteryPowerInversionUrl_DisplayName)]
+    [HelperText(LocalizationKeys.BaseConfiguration.HomeBatteryPowerInversionUrl_HelperText)]
     public string? HomeBatteryPowerInversionUrl { get; set; }
     public Dictionary<string, string> HomeBatteryPowerHeaders { get; set; } = new();
     public Dictionary<string, string> HomeBatteryPowerInversionHeaders { get; set; } = new();
@@ -32,17 +33,17 @@ public class BaseConfigurationBase
     public Dictionary<string, string> CurrentInverterPowerHeaders { get; set; } = new();
     public bool IsModbusCurrentInverterPowerUrl { get; set; }
     [Required]
-    [DisplayName("Power Change Interval")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.UpdateIntervalSeconds_DisplayName)]
     [Postfix("s")]
-    [HelperText("Every x seconds it is checked if any power changes are required.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.UpdateIntervalSeconds_HelperText)]
     public int UpdateIntervalSeconds { get; set; } = 30;
     [Required]
     [Postfix("s")]
-    [HelperText("Be cautious when setting values below 25 seconds as this might result in unexpected bahaviour as cars or charging stations might take some time to update the power.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.SkipPowerChangesOnLastAdjustmentNewerThanSeconds_HelperText)]
     public int SkipPowerChangesOnLastAdjustmentNewerThanSeconds { get; set; } = 25;
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Solar power refresh interval")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.PvValueUpdateIntervalSeconds_DisplayName)]
     [Postfix("s")]
     public int? PvValueUpdateIntervalSeconds { get; set; } = 1;
     [Required]
@@ -53,26 +54,26 @@ public class BaseConfigurationBase
     public string GeoFence { get; set; } = "Home";
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Time with enough solar power until charging starts")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.MinutesUntilSwitchOn_DisplayName)]
     [Postfix("min")]
     public int MinutesUntilSwitchOn { get; set; } = 5;
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Time without enough solar power until charging stops")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.MinutesUntilSwitchOff_DisplayName)]
     [Postfix("min")]
     public int MinutesUntilSwitchOff { get; set; } = 5;
     [Required]
-    [DisplayName("Power Buffer")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.PowerBuffer_DisplayName)]
     [Postfix("W")]
-    [HelperText("Set values higher than 0 to always have some overage (power to grid). Set values lower than 0 to always consume some power from the grid.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.PowerBuffer_HelperText)]
     public int PowerBuffer { get; set; } = 0;
-    [HelperText("If enabled, the configured power buffer is displayed on the home screen, including the option to directly change it.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.AllowPowerBufferChangeOnHome_HelperText)]
     public bool AllowPowerBufferChangeOnHome { get; set; }
-    [HelperText("If enabled, your home geofence location is transfered to the Solar4Car.com servers as well as to the servers of www.visualcrossing.com. At no point will your location data be linked with other data.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.PredictSolarPowerGeneration_HelperText)]
     public bool PredictSolarPowerGeneration { get; set; }
-    [HelperText("If enabled, when a target Soc is set not only grid prices but also estimated solar power generation is used to schedule charging.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.UsePredictedSolarPowerGenerationForChargingSchedules_HelperText)]
     public bool UsePredictedSolarPowerGenerationForChargingSchedules { get; set; }
-    [HelperText("This is in an early beta and might not behave like expected. Loading might take longer than 30 seconds or never load on low performance devices like Raspery Pi 3. This will be fixed in a future update.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.ShowEnergyDataOnHome_HelperText)]
     public bool ShowEnergyDataOnHome { get; set; }
     public string? CurrentPowerToGridJsonPattern { get; set; }
     public decimal CurrentPowerToGridCorrectionFactor { get; set; } = 1;
@@ -82,28 +83,28 @@ public class BaseConfigurationBase
     public decimal HomeBatterySocCorrectionFactor { get; set; } = 1;
     public string? HomeBatteryPowerJsonPattern { get; set; }
     public decimal HomeBatteryPowerCorrectionFactor { get; set; } = 1;
-    [DisplayName("Telegram Bot Key")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.TelegramBotKey_DisplayName)]
     public string? TelegramBotKey { get; set; }
-    [DisplayName("Telegram Channel Id")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.TelegramChannelId_DisplayName)]
     public string? TelegramChannelId { get; set; }
-    [HelperText("If enabled detailed error information are sent via Telegram so developers can find the root cause. This is not needed for normal usage.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.SendStackTraceToTelegram_HelperText)]
     public bool SendStackTraceToTelegram { get; set; }
-    [DisplayName("TeslaMate Database Host")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.TeslaMateDbServer_DisplayName)]
     public string? TeslaMateDbServer { get; set; }
-    [DisplayName("TeslaMate Database Server Port")]
-    [HelperText("You can use the internal port of the TeslaMate database container")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.TeslaMateDbPort_DisplayName)]
+    [HelperText(LocalizationKeys.BaseConfiguration.TeslaMateDbPort_HelperText)]
     public int? TeslaMateDbPort { get; set; }
-    [DisplayName("TeslaMate Database Name")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.TeslaMateDbDatabaseName_DisplayName)]
     public string? TeslaMateDbDatabaseName { get; set; }
-    [DisplayName("TeslaMate Database Username")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.TeslaMateDbUser_DisplayName)]
     public string? TeslaMateDbUser { get; set; }
     [DataType(DataType.Password)]
-    [DisplayName("TeslaMate Database Server Password")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.TeslaMateDbPassword_DisplayName)]
     public string? TeslaMateDbPassword { get; set; }
-    [DisplayName("Mosquito servername")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.MosquitoServer_DisplayName)]
     public string? MosquitoServer { get; set; }
     [Required]
-    [DisplayName("Mqqt ClientId")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.MqqtClientId_DisplayName)]
     public string MqqtClientId { get; set; } = "TeslaSolarCharger";
     public string? CurrentPowerToGridXmlPattern { get; set; }
     public string? CurrentPowerToGridXmlAttributeHeaderName { get; set; }
@@ -122,64 +123,62 @@ public class BaseConfigurationBase
     public string? HomeBatteryPowerXmlAttributeHeaderValue { get; set; }
     public string? HomeBatteryPowerXmlAttributeValueName { get; set; }
 
-    [DisplayName("Dynamic Home Battery Min Soc")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.DynamicHomeBatteryMinSoc_DisplayName)]
     [Postfix("%")]
-    [HelperText("If enabled the Home Battery Min Soc is automatically set based on solar predictions to make sure the home battery is fully charged at the end of the day. This setting is only recommended after having solar predictions enabled for at least two weeks.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.DynamicHomeBatteryMinSoc_HelperText)]
     public bool? DynamicHomeBatteryMinSoc { get; set; }
-    [DisplayName("Home Battery Minimum SoC")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.HomeBatteryMinSoc_DisplayName)]
     [Postfix("%")]
-    [HelperText("Set the SoC your home battery should get charged to before cars start to use full power. Leave empty if you do not have a home battery")]
+    [HelperText(LocalizationKeys.BaseConfiguration.HomeBatteryMinSoc_HelperText)]
     public int? HomeBatteryMinSoc { get; set; }
     [Postfix("%")]
-    [HelperText("Reserve that is always set as min SoC.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.HomeBatteryMinDynamicMinSoc_HelperText)]
     public int HomeBatteryMinDynamicMinSoc { get; set; } = 5;
     [Postfix("%")]
-    [HelperText("Min SoC is never set higher than this value.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.HomeBatteryMaxDynamicMinSoc_HelperText)]
     public int HomeBatteryMaxDynamicMinSoc { get; set; } = 95;
     [Postfix("%")]
-    [HelperText("Used to make sure your home battery does not run out of power even if weather predictions are not correct or your house uses more energy than anticipated.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.DynamicMinSocCalculationBuffer_HelperText)]
     public int DynamicMinSocCalculationBuffer { get; set; } = 50;
-    [HelperText("If enabled, the system charges the home battery so it is full by sunset. If disabled, the system only ensures the battery does not run empty before the next sunrise.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.ForceFullHomeBatteryBySunset_HelperText)]
     public bool ForceFullHomeBatteryBySunset { get; set; } = true;
-    [DisplayName("Home Battery Target charging power")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.HomeBatteryChargingPower_DisplayName)]
     [Postfix("W")]
-    [HelperText(
-        "Set the power your home battery should charge with as long as SoC is below set minimum SoC. Leave empty if you do not have a home battery")]
+    [HelperText(LocalizationKeys.BaseConfiguration.HomeBatteryChargingPower_HelperText)]
     public int? HomeBatteryChargingPower { get; set; }
-    [DisplayName("Home Battery target discharging power")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.HomeBatteryDischargingPower_DisplayName)]
     [Postfix("W")]
-    [HelperText(
-        "Used to discharge the home battery when option is set in either a charging target or directly at the car.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.HomeBatteryDischargingPower_HelperText)]
     public int? HomeBatteryDischargingPower { get; set; }
-    [DisplayName("Home Battery Usable energy")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.HomeBatteryUsableEnergy_DisplayName)]
     [Postfix("kWh")]
-    [HelperText("Set the usable energy your home battery has.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.HomeBatteryUsableEnergy_HelperText)]
     public double? HomeBatteryUsableEnergy { get; set; }
-    [HelperText("When enabled TSC discharges the home battery to its Min Soc after sunrise and before sunset. Note: Charging of cars is only started if minimum difference between actual home battery soc and min soc is at least 10%.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.DischargeHomeBatteryToMinSocDuringDay_HelperText)]
     public bool DischargeHomeBatteryToMinSocDuringDay { get; set; }
     [Postfix("%")]
-    [HelperText("Energy lost when charging cars. Is used to calculate charging schedules based on battery capacity.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.CarChargeLoss_HelperText)]
     public int CarChargeLoss { get; set; } = 15;
-    [DisplayName("Max combined current")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.MaxCombinedCurrent_DisplayName)]
     [Postfix("A")]
-    [HelperText("Set a value if you want to reduce the max combined used current per phase of all cars. E.g. if you have two cars each set to max 16A but your installation can only handle 20A per phase you can set 20A here. So if one car uses 16A per phase the other car can only use 4A per phase. Note: Power is distributed based on the set car priorities.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.MaxCombinedCurrent_HelperText)]
     public int? MaxCombinedCurrent { get; set; }
-    [DisplayName("Max Inverter AC Power")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.MaxInverterAcPower_DisplayName)]
     [Postfix("W")]
-    [HelperText("If you have a hybrid inverter that has more DC than AC power insert the maximum AC Power here. This is a very rare, so in most cases you can leave this field empty.")]
+    [HelperText(LocalizationKeys.BaseConfiguration.MaxInverterAcPower_HelperText)]
     public int? MaxInverterAcPower { get; set; }
     public string? BleApiBaseUrl { get; set; }
-    [DisplayName("Use TeslaMate Integration")]
-    [HelperText("When you use TeslaMate you can enable this so calculated charging costs from TSC are set in TeslaMate. Note: The charging costs in TeslaMate are only updated ever 24 hours.")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.UseTeslaMateIntegration_DisplayName)]
+    [HelperText(LocalizationKeys.BaseConfiguration.UseTeslaMateIntegration_HelperText)]
     public bool UseTeslaMateIntegration { get; set; }
-    [DisplayName("Use TeslaMate as Data Source")]
-    [HelperText("If enabled TeslaMate MQTT is used as datasource. If disabled Tesla API is directly called. Note: If you use TSC without TeslaMate the setting here does not matter. Then the Tesla API is used always.")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.UseTeslaMateAsDataSource_DisplayName)]
+    [HelperText(LocalizationKeys.BaseConfiguration.UseTeslaMateAsDataSource_HelperText)]
     public bool UseTeslaMateAsDataSource { get; set; }
     public double HomeGeofenceLongitude { get; set; } = 13.3761736; //Do not change the default value as depending on this the Geofence from TeslaMate is converted or not
     public double HomeGeofenceLatitude { get; set; } = 52.5185238; //Do not change the default value as depending on this the Geofence from TeslaMate is converted or not
-    [DisplayName("Home Radius")]
+    [DisplayName(LocalizationKeys.BaseConfiguration.HomeGeofenceRadius_DisplayName)]
     [Postfix("m")]
-    [HelperText("Increase or decrease the radius of the home geofence. Note: Values below 50m are note recommended")]
+    [HelperText(LocalizationKeys.BaseConfiguration.HomeGeofenceRadius_HelperText)]
     public int HomeGeofenceRadius { get; set; } = 50;
 
     public FrontendConfiguration? FrontendConfiguration { get; set; }

--- a/TeslaSolarCharger/Shared/Dtos/Home/DtoNotChargingWithExpectedPowerReason.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Home/DtoNotChargingWithExpectedPowerReason.cs
@@ -1,4 +1,8 @@
-﻿namespace TeslaSolarCharger.Shared.Dtos.Home;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace TeslaSolarCharger.Shared.Dtos.Home;
 
 public class DtoNotChargingWithExpectedPowerReason
 {
@@ -7,8 +11,8 @@ public class DtoNotChargingWithExpectedPowerReason
     public DtoNotChargingWithExpectedPowerReason()
 #pragma warning restore CS8618, CS9264
     {
-        
     }
+
     public DtoNotChargingWithExpectedPowerReason(string reason)
     {
         Reason = reason;
@@ -19,6 +23,27 @@ public class DtoNotChargingWithExpectedPowerReason
         ReasonEndTime = reasonEndTime;
     }
 
-    public string Reason { get; set; }
+    public static DtoNotChargingWithExpectedPowerReason CreateLocalized(string resourceKey, params string[] formatParameters)
+    {
+        return new DtoNotChargingWithExpectedPowerReason()
+        {
+            ResourceKey = resourceKey,
+            FormatParameters = formatParameters.ToList(),
+        };
+    }
+
+    public static DtoNotChargingWithExpectedPowerReason CreateLocalized(string resourceKey, DateTimeOffset? reasonEndTime, params string[] formatParameters)
+    {
+        var reason = CreateLocalized(resourceKey, formatParameters);
+        reason.ReasonEndTime = reasonEndTime;
+        return reason;
+    }
+
+    public string? Reason { get; set; }
+    public string? ResourceKey { get; set; }
+    public List<string> FormatParameters { get; set; } = new();
     public DateTimeOffset? ReasonEndTime { get; set; }
+
+    [JsonIgnore]
+    public bool HasResourceKey => !string.IsNullOrWhiteSpace(ResourceKey);
 }

--- a/TeslaSolarCharger/Shared/Helper/StringHelper.cs
+++ b/TeslaSolarCharger/Shared/Helper/StringHelper.cs
@@ -1,20 +1,30 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;
 using TeslaSolarCharger.Shared.Helper.Contracts;
+using TeslaSolarCharger.Shared.Localization;
 
 namespace TeslaSolarCharger.Shared.Helper;
 
-public class StringHelper(ILogger<StringHelper> logger) : IStringHelper
+public class StringHelper : IStringHelper
 {
+    private readonly ILogger<StringHelper> _logger;
+    private readonly IAppStringLocalizer _localizer;
+
+    public StringHelper(ILogger<StringHelper> logger, IAppStringLocalizer localizer)
+    {
+        _logger = logger;
+        _localizer = localizer;
+    }
+
     public string MakeNonWhiteSpaceCapitalString(string inputString)
     {
-        logger.LogTrace("{method}({inputString})", nameof(MakeNonWhiteSpaceCapitalString), inputString);
+        _logger.LogTrace("{method}({inputString})", nameof(MakeNonWhiteSpaceCapitalString), inputString);
         return string.Concat(inputString.ToUpper().Where(c => !char.IsWhiteSpace(c)));
     }
 
     public string GenerateFriendlyStringWithOutIdSuffix(string inputString)
     {
-        logger.LogTrace("{method}({inputString})", nameof(GenerateFriendlyStringWithOutIdSuffix), inputString);
+        _logger.LogTrace("{method}({inputString})", nameof(GenerateFriendlyStringWithOutIdSuffix), inputString);
         var friendlyString = GenerateFriendlyStringFromPascalString(inputString);
         if (friendlyString.EndsWith(" Id"))
         {
@@ -32,6 +42,11 @@ public class StringHelper(ILogger<StringHelper> logger) : IStringHelper
 
     public string GenerateFriendlyStringFromPascalString(string inputString)
     {
+        if (_localizer.TryGetValue(inputString, out var localizedValue) && !string.IsNullOrWhiteSpace(localizedValue))
+        {
+            return localizedValue;
+        }
+
         return Regex.Replace(inputString, "(\\B[A-Z])", " $1");
     }
 }

--- a/TeslaSolarCharger/Shared/Localization/AppStringLocalizer.cs
+++ b/TeslaSolarCharger/Shared/Localization/AppStringLocalizer.cs
@@ -1,0 +1,118 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Resources;
+using Microsoft.Extensions.Logging;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+public sealed class AppStringLocalizer : IAppStringLocalizer
+{
+    private const string ResourceBaseName = "TeslaSolarCharger.Shared.Localization.AppStrings";
+    private readonly ILogger<AppStringLocalizer> _logger;
+    private readonly ResourceManager _resourceManager;
+    private readonly HashSet<string> _availableKeys;
+    private readonly HashSet<string> _missingKeys = new(StringComparer.OrdinalIgnoreCase);
+
+    public AppStringLocalizer(ILogger<AppStringLocalizer> logger)
+    {
+        _logger = logger;
+        _resourceManager = new ResourceManager(ResourceBaseName, typeof(AppStringLocalizer).Assembly);
+        _availableKeys = LoadAvailableKeys();
+    }
+
+    public string this[string key] => GetString(key);
+
+    public string this[string key, params object[] arguments] => FormatString(key, arguments);
+
+    public string this[LocalizationKey key] => GetString(key.Value);
+
+    public string this[LocalizationKey key, params object[] arguments] => FormatString(key.Value, arguments);
+
+    public bool TryGetValue(string key, out string value)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        if (!_availableKeys.Contains(key))
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = GetString(key);
+        return true;
+    }
+
+    public bool TryGetValue(LocalizationKey key, out string value) => TryGetValue(key.Value, out value);
+
+    private HashSet<string> LoadAvailableKeys()
+    {
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var resourceSet = _resourceManager.GetResourceSet(CultureInfo.InvariantCulture, true, true);
+            if (resourceSet != null)
+            {
+                foreach (DictionaryEntry entry in resourceSet)
+                {
+                    if (entry.Key is string key)
+                    {
+                        result.Add(key);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load localization resources");
+        }
+
+        return result;
+    }
+
+    private string GetString(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return string.Empty;
+        }
+
+        var value = _resourceManager.GetString(key, CultureInfo.CurrentUICulture)
+                    ?? _resourceManager.GetString(key, CultureInfo.InvariantCulture);
+
+        if (value == null)
+        {
+            if (_missingKeys.Add(key))
+            {
+                _logger.LogWarning("Missing localization string for key '{key}' in culture '{culture}'", key, CultureInfo.CurrentUICulture.Name);
+            }
+
+            return key;
+        }
+
+        return value;
+    }
+
+    private string FormatString(string key, params object[] arguments)
+    {
+        var format = GetString(key);
+        if (arguments == null || arguments.Length == 0)
+        {
+            return format;
+        }
+
+        try
+        {
+            return string.Format(CultureInfo.CurrentCulture, format, arguments);
+        }
+        catch (FormatException ex)
+        {
+            _logger.LogError(ex, "Failed to format localized string for key '{key}'", key);
+            return format;
+        }
+    }
+}

--- a/TeslaSolarCharger/Shared/Localization/AppStrings.de.resx
+++ b/TeslaSolarCharger/Shared/Localization/AppStrings.de.resx
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BaseConfiguration.HomeBatteryPowerInversionUrl.DisplayName" xml:space="preserve">
+    <value>HomeBatteryPowerInversion URL</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryPowerInversionUrl.HelperText" xml:space="preserve">
+    <value>Nutzen Sie diese Einstellung, wenn Sie die Leistung der Hausbatterie dynamisch invertieren müssen. Hinweis: Als Antwort sind nur 0 und 1 erlaubt. Soweit bekannt, wird dies nur bei Sungrow-Wechselrichtern benötigt.</value>
+  </data>
+  <data name="BaseConfiguration.UpdateIntervalSeconds.DisplayName" xml:space="preserve">
+    <value>Intervall für Leistungsänderungen</value>
+  </data>
+  <data name="BaseConfiguration.UpdateIntervalSeconds.HelperText" xml:space="preserve">
+    <value>In diesem Intervall wird geprüft, ob Leistungsänderungen erforderlich sind.</value>
+  </data>
+  <data name="BaseConfiguration.SkipPowerChangesOnLastAdjustmentNewerThanSeconds.HelperText" xml:space="preserve">
+    <value>Seien Sie vorsichtig bei Werten unter 25 Sekunden, da Fahrzeuge oder Ladestationen unter Umständen länger brauchen, um die Leistung zu aktualisieren.</value>
+  </data>
+  <data name="BaseConfiguration.PvValueUpdateIntervalSeconds.DisplayName" xml:space="preserve">
+    <value>Aktualisierungsintervall für Solarleistung</value>
+  </data>
+  <data name="BaseConfiguration.MinutesUntilSwitchOn.DisplayName" xml:space="preserve">
+    <value>Zeit mit ausreichender Solarleistung bis zum Start</value>
+  </data>
+  <data name="BaseConfiguration.MinutesUntilSwitchOff.DisplayName" xml:space="preserve">
+    <value>Zeit ohne ausreichende Solarleistung bis zum Stopp</value>
+  </data>
+  <data name="BaseConfiguration.PowerBuffer.DisplayName" xml:space="preserve">
+    <value>Leistungspuffer</value>
+  </data>
+  <data name="BaseConfiguration.PowerBuffer.HelperText" xml:space="preserve">
+    <value>Werte größer 0 sorgen immer für Überschuss (Einspeisung). Werte kleiner 0 führen dazu, dass dauerhaft etwas Netzstrom bezogen wird.</value>
+  </data>
+  <data name="BaseConfiguration.AllowPowerBufferChangeOnHome.HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, wird der konfigurierte Leistungspuffer auf der Startseite angezeigt und kann dort direkt angepasst werden.</value>
+  </data>
+  <data name="BaseConfiguration.PredictSolarPowerGeneration.HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, wird Ihr Home-Geofence sowohl an die Solar4Car.com-Server als auch an www.visualcrossing.com übertragen. Die Standortdaten werden zu keinem Zeitpunkt mit anderen Daten verknüpft.</value>
+  </data>
+  <data name="BaseConfiguration.UsePredictedSolarPowerGenerationForChargingSchedules.HelperText" xml:space="preserve">
+    <value>Ist ein Ziel-SoC gesetzt, werden bei aktivierter Option sowohl Strompreise als auch prognostizierte Solarerzeugung für die Ladeplanung verwendet.</value>
+  </data>
+  <data name="BaseConfiguration.ShowEnergyDataOnHome.HelperText" xml:space="preserve">
+    <value>Diese Funktion befindet sich in einer frühen Beta und kann sich unerwartet verhalten. Das Laden kann länger als 30 Sekunden dauern oder auf Geräten mit geringer Leistung (z. B. Raspberry Pi 3) ganz ausbleiben. Dies wird in einem zukünftigen Update verbessert.</value>
+  </data>
+  <data name="BaseConfiguration.TelegramBotKey.DisplayName" xml:space="preserve">
+    <value>Telegram-Bot-Schlüssel</value>
+  </data>
+  <data name="BaseConfiguration.TelegramChannelId.DisplayName" xml:space="preserve">
+    <value>Telegram-Kanal-ID</value>
+  </data>
+  <data name="BaseConfiguration.SendStackTraceToTelegram.HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, werden detaillierte Fehlerinformationen per Telegram versendet, damit Entwickler die Ursache finden können. Für den normalen Betrieb nicht erforderlich.</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbServer.DisplayName" xml:space="preserve">
+    <value>TeslaMate-Datenbankhost</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbPort.DisplayName" xml:space="preserve">
+    <value>TeslaMate-Datenbankport</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbPort.HelperText" xml:space="preserve">
+    <value>Sie können den internen Port des TeslaMate-Datenbankcontainers verwenden.</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbDatabaseName.DisplayName" xml:space="preserve">
+    <value>TeslaMate-Datenbankname</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbUser.DisplayName" xml:space="preserve">
+    <value>TeslaMate-Datenbankbenutzer</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbPassword.DisplayName" xml:space="preserve">
+    <value>TeslaMate-Datenbankpasswort</value>
+  </data>
+  <data name="BaseConfiguration.MosquitoServer.DisplayName" xml:space="preserve">
+    <value>Mosquito-Servername</value>
+  </data>
+  <data name="BaseConfiguration.MqqtClientId.DisplayName" xml:space="preserve">
+    <value>MQTT-Client-ID</value>
+  </data>
+  <data name="BaseConfiguration.DynamicHomeBatteryMinSoc.DisplayName" xml:space="preserve">
+    <value>Dynamischer Mindest-SoC der Hausbatterie</value>
+  </data>
+  <data name="BaseConfiguration.DynamicHomeBatteryMinSoc.HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, wird der Mindest-SoC der Hausbatterie anhand der Solarprognosen automatisch gesetzt, sodass sie zum Tagesende voll ist. Diese Einstellung wird erst nach mindestens zwei Wochen aktivierter Solarprognosen empfohlen.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryMinSoc.DisplayName" xml:space="preserve">
+    <value>Mindest-SoC der Hausbatterie</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryMinSoc.HelperText" xml:space="preserve">
+    <value>Legen Sie den SoC fest, auf den Ihre Hausbatterie geladen wird, bevor Fahrzeuge mit voller Leistung laden. Leer lassen, falls keine Hausbatterie vorhanden ist.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryMinDynamicMinSoc.HelperText" xml:space="preserve">
+    <value>Reserve, die immer als Mindest-SoC gesetzt wird.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryMaxDynamicMinSoc.HelperText" xml:space="preserve">
+    <value>Der Mindest-SoC wird nie höher als dieser Wert gesetzt.</value>
+  </data>
+  <data name="BaseConfiguration.DynamicMinSocCalculationBuffer.HelperText" xml:space="preserve">
+    <value>Stellt sicher, dass die Hausbatterie nicht leer läuft, selbst wenn Vorhersagen ungenau sind oder der Verbrauch höher ist als erwartet.</value>
+  </data>
+  <data name="BaseConfiguration.ForceFullHomeBatteryBySunset.HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, lädt das System die Hausbatterie bis zum Sonnenuntergang voll. Wenn deaktiviert, wird nur sichergestellt, dass sie bis zum nächsten Sonnenaufgang nicht leer wird.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryChargingPower.DisplayName" xml:space="preserve">
+    <value>Ziel-Ladeleistung der Hausbatterie</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryChargingPower.HelperText" xml:space="preserve">
+    <value>Legen Sie die Leistung fest, mit der die Hausbatterie geladen wird, solange der SoC unter dem Mindestwert liegt. Leer lassen, wenn keine Hausbatterie vorhanden ist.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryDischargingPower.DisplayName" xml:space="preserve">
+    <value>Ziel-Entladeleistung der Hausbatterie</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryDischargingPower.HelperText" xml:space="preserve">
+    <value>Wird verwendet, um die Hausbatterie zu entladen, wenn dies in einem Ladeziel oder direkt am Fahrzeug aktiviert ist.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryUsableEnergy.DisplayName" xml:space="preserve">
+    <value>Nutzbare Energie der Hausbatterie</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryUsableEnergy.HelperText" xml:space="preserve">
+    <value>Tragen Sie die nutzbare Energie Ihrer Hausbatterie ein.</value>
+  </data>
+  <data name="BaseConfiguration.DischargeHomeBatteryToMinSocDuringDay.HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, entlädt TSC die Hausbatterie tagsüber bis zum Mindest-SoC. Hinweis: Das Laden von Autos startet erst, wenn die Differenz zwischen aktuellem SoC und Mindest-SoC mindestens 10 % beträgt.</value>
+  </data>
+  <data name="BaseConfiguration.CarChargeLoss.HelperText" xml:space="preserve">
+    <value>Energieverlust beim Laden von Autos. Wird verwendet, um Ladepläne anhand der Batteriekapazität zu berechnen.</value>
+  </data>
+  <data name="BaseConfiguration.MaxCombinedCurrent.DisplayName" xml:space="preserve">
+    <value>Maximaler Gesamtstrom</value>
+  </data>
+  <data name="BaseConfiguration.MaxCombinedCurrent.HelperText" xml:space="preserve">
+    <value>Begrenzen Sie den maximal kombinierten Strom pro Phase aller Fahrzeuge. Beispiel: Wenn zwei Fahrzeuge mit je 16 A laden können, Ihre Installation aber nur 20 A pro Phase zulässt, stellen Sie hier 20 A ein. Nutzt ein Fahrzeug 16 A, bleiben für das andere 4 A.</value>
+  </data>
+  <data name="BaseConfiguration.MaxInverterAcPower.DisplayName" xml:space="preserve">
+    <value>Maximale AC-Leistung des Wechselrichters</value>
+  </data>
+  <data name="BaseConfiguration.MaxInverterAcPower.HelperText" xml:space="preserve">
+    <value>Wenn Sie einen Hybrid-Wechselrichter mit mehr DC- als AC-Leistung haben, geben Sie hier die maximale AC-Leistung an. In den meisten Fällen kann dieses Feld leer bleiben.</value>
+  </data>
+  <data name="BaseConfiguration.UseTeslaMateIntegration.DisplayName" xml:space="preserve">
+    <value>TeslaMate-Integration verwenden</value>
+  </data>
+  <data name="BaseConfiguration.UseTeslaMateIntegration.HelperText" xml:space="preserve">
+    <value>Wenn Sie TeslaMate nutzen, können Sie hier aktivieren, dass berechnete Ladekosten aus TSC in TeslaMate übernommen werden. Hinweis: In TeslaMate werden die Kosten nur alle 24 Stunden aktualisiert.</value>
+  </data>
+  <data name="BaseConfiguration.UseTeslaMateAsDataSource.DisplayName" xml:space="preserve">
+    <value>TeslaMate als Datenquelle verwenden</value>
+  </data>
+  <data name="BaseConfiguration.UseTeslaMateAsDataSource.HelperText" xml:space="preserve">
+    <value>Wenn aktiviert, wird TeslaMate MQTT als Datenquelle genutzt. Ist die Option deaktiviert, wird die Tesla-API direkt verwendet. Ohne TeslaMate ist diese Einstellung wirkungslos, da immer die Tesla-API genutzt wird.</value>
+  </data>
+  <data name="BaseConfiguration.HomeGeofenceRadius.DisplayName" xml:space="preserve">
+    <value>Radius zu Hause</value>
+  </data>
+  <data name="BaseConfiguration.HomeGeofenceRadius.HelperText" xml:space="preserve">
+    <value>Vergrößern oder verkleinern Sie den Radius des Home-Geofence. Werte unter 50 m werden nicht empfohlen.</value>
+  </data>
+  <data name="NotChargingReasons.CarFullyCharged" xml:space="preserve">
+    <value>Fahrzeug ist vollständig geladen</value>
+  </data>
+  <data name="Components.NotChargingReasons.Heading" xml:space="preserve">
+    <value>{0} Gründe, warum der Ladepunkt mit einer anderen Leistung lädt als erwartet</value>
+  </data>
+  <data name="Components.NotChargingReasons.Remaining" xml:space="preserve">
+    <value>verbleibend</value>
+  </data>
+  <data name="Components.NotChargingReasons.ReasonWithCountdown" xml:space="preserve">
+    <value>{0} ({1} verbleibend)</value>
+  </data>
+  <data name="Components.NotChargingReasons.NextEnding" xml:space="preserve">
+    <value>{0}:</value>
+  </data>
+</root>

--- a/TeslaSolarCharger/Shared/Localization/AppStrings.resx
+++ b/TeslaSolarCharger/Shared/Localization/AppStrings.resx
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BaseConfiguration.HomeBatteryPowerInversionUrl.DisplayName" xml:space="preserve">
+    <value>HomeBatteryPowerInversion Url</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryPowerInversionUrl.HelperText" xml:space="preserve">
+    <value>Use this if you have to dynamically invert the home battery power. Note: Only 0 and 1 are allowed as response. As far as I know this is only needed with Sungrow Inverters.</value>
+  </data>
+  <data name="BaseConfiguration.UpdateIntervalSeconds.DisplayName" xml:space="preserve">
+    <value>Power Change Interval</value>
+  </data>
+  <data name="BaseConfiguration.UpdateIntervalSeconds.HelperText" xml:space="preserve">
+    <value>Every x seconds it is checked if any power changes are required.</value>
+  </data>
+  <data name="BaseConfiguration.SkipPowerChangesOnLastAdjustmentNewerThanSeconds.HelperText" xml:space="preserve">
+    <value>Be cautious when setting values below 25 seconds as this might result in unexpected behaviour as cars or charging stations might take some time to update the power.</value>
+  </data>
+  <data name="BaseConfiguration.PvValueUpdateIntervalSeconds.DisplayName" xml:space="preserve">
+    <value>Solar power refresh interval</value>
+  </data>
+  <data name="BaseConfiguration.MinutesUntilSwitchOn.DisplayName" xml:space="preserve">
+    <value>Time with enough solar power until charging starts</value>
+  </data>
+  <data name="BaseConfiguration.MinutesUntilSwitchOff.DisplayName" xml:space="preserve">
+    <value>Time without enough solar power until charging stops</value>
+  </data>
+  <data name="BaseConfiguration.PowerBuffer.DisplayName" xml:space="preserve">
+    <value>Power Buffer</value>
+  </data>
+  <data name="BaseConfiguration.PowerBuffer.HelperText" xml:space="preserve">
+    <value>Set values higher than 0 to always have some overage (power to grid). Set values lower than 0 to always consume some power from the grid.</value>
+  </data>
+  <data name="BaseConfiguration.AllowPowerBufferChangeOnHome.HelperText" xml:space="preserve">
+    <value>If enabled, the configured power buffer is displayed on the home screen, including the option to directly change it.</value>
+  </data>
+  <data name="BaseConfiguration.PredictSolarPowerGeneration.HelperText" xml:space="preserve">
+    <value>If enabled, your home geofence location is transferred to the Solar4Car.com servers as well as to the servers of www.visualcrossing.com. At no point will your location data be linked with other data.</value>
+  </data>
+  <data name="BaseConfiguration.UsePredictedSolarPowerGenerationForChargingSchedules.HelperText" xml:space="preserve">
+    <value>If enabled, when a target Soc is set not only grid prices but also estimated solar power generation is used to schedule charging.</value>
+  </data>
+  <data name="BaseConfiguration.ShowEnergyDataOnHome.HelperText" xml:space="preserve">
+    <value>This is in an early beta and might not behave like expected. Loading might take longer than 30 seconds or never load on low performance devices like Raspery Pi 3. This will be fixed in a future update.</value>
+  </data>
+  <data name="BaseConfiguration.TelegramBotKey.DisplayName" xml:space="preserve">
+    <value>Telegram Bot Key</value>
+  </data>
+  <data name="BaseConfiguration.TelegramChannelId.DisplayName" xml:space="preserve">
+    <value>Telegram Channel Id</value>
+  </data>
+  <data name="BaseConfiguration.SendStackTraceToTelegram.HelperText" xml:space="preserve">
+    <value>If enabled detailed error information are sent via Telegram so developers can find the root cause. This is not needed for normal usage.</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbServer.DisplayName" xml:space="preserve">
+    <value>TeslaMate Database Host</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbPort.DisplayName" xml:space="preserve">
+    <value>TeslaMate Database Server Port</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbPort.HelperText" xml:space="preserve">
+    <value>You can use the internal port of the TeslaMate database container</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbDatabaseName.DisplayName" xml:space="preserve">
+    <value>TeslaMate Database Name</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbUser.DisplayName" xml:space="preserve">
+    <value>TeslaMate Database Username</value>
+  </data>
+  <data name="BaseConfiguration.TeslaMateDbPassword.DisplayName" xml:space="preserve">
+    <value>TeslaMate Database Server Password</value>
+  </data>
+  <data name="BaseConfiguration.MosquitoServer.DisplayName" xml:space="preserve">
+    <value>Mosquito servername</value>
+  </data>
+  <data name="BaseConfiguration.MqqtClientId.DisplayName" xml:space="preserve">
+    <value>Mqqt ClientId</value>
+  </data>
+  <data name="BaseConfiguration.DynamicHomeBatteryMinSoc.DisplayName" xml:space="preserve">
+    <value>Dynamic Home Battery Min Soc</value>
+  </data>
+  <data name="BaseConfiguration.DynamicHomeBatteryMinSoc.HelperText" xml:space="preserve">
+    <value>If enabled the Home Battery Min Soc is automatically set based on solar predictions to make sure the home battery is fully charged at the end of the day. This setting is only recommended after having solar predictions enabled for at least two weeks.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryMinSoc.DisplayName" xml:space="preserve">
+    <value>Home Battery Minimum SoC</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryMinSoc.HelperText" xml:space="preserve">
+    <value>Set the SoC your home battery should get charged to before cars start to use full power. Leave empty if you do not have a home battery</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryMinDynamicMinSoc.HelperText" xml:space="preserve">
+    <value>Reserve that is always set as min SoC.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryMaxDynamicMinSoc.HelperText" xml:space="preserve">
+    <value>Min SoC is never set higher than this value.</value>
+  </data>
+  <data name="BaseConfiguration.DynamicMinSocCalculationBuffer.HelperText" xml:space="preserve">
+    <value>Used to make sure your home battery does not run out of power even if weather predictions are not correct or your house uses more energy than anticipated.</value>
+  </data>
+  <data name="BaseConfiguration.ForceFullHomeBatteryBySunset.HelperText" xml:space="preserve">
+    <value>If enabled, the system charges the home battery so it is full by sunset. If disabled, the system only ensures the battery does not run empty before the next sunrise.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryChargingPower.DisplayName" xml:space="preserve">
+    <value>Home Battery Target charging power</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryChargingPower.HelperText" xml:space="preserve">
+    <value>Set the power your home battery should charge with as long as SoC is below set minimum SoC. Leave empty if you do not have a home battery</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryDischargingPower.DisplayName" xml:space="preserve">
+    <value>Home Battery target discharging power</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryDischargingPower.HelperText" xml:space="preserve">
+    <value>Used to discharge the home battery when option is set in either a charging target or directly at the car.</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryUsableEnergy.DisplayName" xml:space="preserve">
+    <value>Home Battery Usable energy</value>
+  </data>
+  <data name="BaseConfiguration.HomeBatteryUsableEnergy.HelperText" xml:space="preserve">
+    <value>Set the usable energy your home battery has.</value>
+  </data>
+  <data name="BaseConfiguration.DischargeHomeBatteryToMinSocDuringDay.HelperText" xml:space="preserve">
+    <value>When enabled TSC discharges the home battery to its Min Soc after sunrise and before sunset. Note: Charging of cars is only started if minimum difference between actual home battery soc and min soc is at least 10%.</value>
+  </data>
+  <data name="BaseConfiguration.CarChargeLoss.HelperText" xml:space="preserve">
+    <value>Energy lost when charging cars. Is used to calculate charging schedules based on battery capacity.</value>
+  </data>
+  <data name="BaseConfiguration.MaxCombinedCurrent.DisplayName" xml:space="preserve">
+    <value>Max combined current</value>
+  </data>
+  <data name="BaseConfiguration.MaxCombinedCurrent.HelperText" xml:space="preserve">
+    <value>Set a value if you want to reduce the max combined used current per phase of all cars. E.g. if you have two cars each set to max 16A but your installation can only handle 20A per phase you can set 20A here. So if one car uses 16A per phase the other car can only use 4A per phase. Note: Power is distributed based on the set car priorities.</value>
+  </data>
+  <data name="BaseConfiguration.MaxInverterAcPower.DisplayName" xml:space="preserve">
+    <value>Max Inverter AC Power</value>
+  </data>
+  <data name="BaseConfiguration.MaxInverterAcPower.HelperText" xml:space="preserve">
+    <value>If you have a hybrid inverter that has more DC than AC power insert the maximum AC Power here. This is a very rare, so in most cases you can leave this field empty.</value>
+  </data>
+  <data name="BaseConfiguration.UseTeslaMateIntegration.DisplayName" xml:space="preserve">
+    <value>Use TeslaMate Integration</value>
+  </data>
+  <data name="BaseConfiguration.UseTeslaMateIntegration.HelperText" xml:space="preserve">
+    <value>When you use TeslaMate you can enable this so calculated charging costs from TSC are set in TeslaMate. Note: The charging costs in TeslaMate are only updated ever 24 hours.</value>
+  </data>
+  <data name="BaseConfiguration.UseTeslaMateAsDataSource.DisplayName" xml:space="preserve">
+    <value>Use TeslaMate as Data Source</value>
+  </data>
+  <data name="BaseConfiguration.UseTeslaMateAsDataSource.HelperText" xml:space="preserve">
+    <value>If enabled TeslaMate MQTT is used as datasource. If disabled Tesla API is directly called. Note: If you use TSC without TeslaMate the setting here does not matter. Then the Tesla API is used always.</value>
+  </data>
+  <data name="BaseConfiguration.HomeGeofenceRadius.DisplayName" xml:space="preserve">
+    <value>Home Radius</value>
+  </data>
+  <data name="BaseConfiguration.HomeGeofenceRadius.HelperText" xml:space="preserve">
+    <value>Increase or decrease the radius of the home geofence. Note: Values below 50m are not recommended</value>
+  </data>
+  <data name="NotChargingReasons.CarFullyCharged" xml:space="preserve">
+    <value>Car is fully charged</value>
+  </data>
+  <data name="Components.NotChargingReasons.Heading" xml:space="preserve">
+    <value>{0} reason(s) why loadpoint charges with different power than you might expect</value>
+  </data>
+  <data name="Components.NotChargingReasons.Remaining" xml:space="preserve">
+    <value>remaining</value>
+  </data>
+  <data name="Components.NotChargingReasons.ReasonWithCountdown" xml:space="preserve">
+    <value>{0} ({1} remaining)</value>
+  </data>
+  <data name="Components.NotChargingReasons.NextEnding" xml:space="preserve">
+    <value>{0}:</value>
+  </data>
+</root>

--- a/TeslaSolarCharger/Shared/Localization/IAppStringLocalizer.cs
+++ b/TeslaSolarCharger/Shared/Localization/IAppStringLocalizer.cs
@@ -1,0 +1,11 @@
+namespace TeslaSolarCharger.Shared.Localization;
+
+public interface IAppStringLocalizer
+{
+    string this[string key] { get; }
+    string this[string key, params object[] arguments] { get; }
+    string this[LocalizationKey key] { get; }
+    string this[LocalizationKey key, params object[] arguments] { get; }
+    bool TryGetValue(string key, out string value);
+    bool TryGetValue(LocalizationKey key, out string value);
+}

--- a/TeslaSolarCharger/Shared/Localization/LocalizationKey.cs
+++ b/TeslaSolarCharger/Shared/Localization/LocalizationKey.cs
@@ -1,0 +1,6 @@
+namespace TeslaSolarCharger.Shared.Localization;
+
+public readonly record struct LocalizationKey(string Value)
+{
+    public override string ToString() => Value;
+}

--- a/TeslaSolarCharger/Shared/Localization/LocalizationKeys.cs
+++ b/TeslaSolarCharger/Shared/Localization/LocalizationKeys.cs
@@ -1,0 +1,133 @@
+namespace TeslaSolarCharger.Shared.Localization;
+
+public static class LocalizationKeys
+{
+    public static class BaseConfiguration
+    {
+        public const string HomeBatteryPowerInversionUrl_DisplayName = "BaseConfiguration.HomeBatteryPowerInversionUrl.DisplayName";
+        public const string HomeBatteryPowerInversionUrl_HelperText = "BaseConfiguration.HomeBatteryPowerInversionUrl.HelperText";
+        public const string UpdateIntervalSeconds_DisplayName = "BaseConfiguration.UpdateIntervalSeconds.DisplayName";
+        public const string UpdateIntervalSeconds_HelperText = "BaseConfiguration.UpdateIntervalSeconds.HelperText";
+        public const string SkipPowerChangesOnLastAdjustmentNewerThanSeconds_HelperText = "BaseConfiguration.SkipPowerChangesOnLastAdjustmentNewerThanSeconds.HelperText";
+        public const string PvValueUpdateIntervalSeconds_DisplayName = "BaseConfiguration.PvValueUpdateIntervalSeconds.DisplayName";
+        public const string MinutesUntilSwitchOn_DisplayName = "BaseConfiguration.MinutesUntilSwitchOn.DisplayName";
+        public const string MinutesUntilSwitchOff_DisplayName = "BaseConfiguration.MinutesUntilSwitchOff.DisplayName";
+        public const string PowerBuffer_DisplayName = "BaseConfiguration.PowerBuffer.DisplayName";
+        public const string PowerBuffer_HelperText = "BaseConfiguration.PowerBuffer.HelperText";
+        public const string AllowPowerBufferChangeOnHome_HelperText = "BaseConfiguration.AllowPowerBufferChangeOnHome.HelperText";
+        public const string PredictSolarPowerGeneration_HelperText = "BaseConfiguration.PredictSolarPowerGeneration.HelperText";
+        public const string UsePredictedSolarPowerGenerationForChargingSchedules_HelperText = "BaseConfiguration.UsePredictedSolarPowerGenerationForChargingSchedules.HelperText";
+        public const string ShowEnergyDataOnHome_HelperText = "BaseConfiguration.ShowEnergyDataOnHome.HelperText";
+        public const string TelegramBotKey_DisplayName = "BaseConfiguration.TelegramBotKey.DisplayName";
+        public const string TelegramChannelId_DisplayName = "BaseConfiguration.TelegramChannelId.DisplayName";
+        public const string SendStackTraceToTelegram_HelperText = "BaseConfiguration.SendStackTraceToTelegram.HelperText";
+        public const string TeslaMateDbServer_DisplayName = "BaseConfiguration.TeslaMateDbServer.DisplayName";
+        public const string TeslaMateDbPort_DisplayName = "BaseConfiguration.TeslaMateDbPort.DisplayName";
+        public const string TeslaMateDbPort_HelperText = "BaseConfiguration.TeslaMateDbPort.HelperText";
+        public const string TeslaMateDbDatabaseName_DisplayName = "BaseConfiguration.TeslaMateDbDatabaseName.DisplayName";
+        public const string TeslaMateDbUser_DisplayName = "BaseConfiguration.TeslaMateDbUser.DisplayName";
+        public const string TeslaMateDbPassword_DisplayName = "BaseConfiguration.TeslaMateDbPassword.DisplayName";
+        public const string MosquitoServer_DisplayName = "BaseConfiguration.MosquitoServer.DisplayName";
+        public const string MqqtClientId_DisplayName = "BaseConfiguration.MqqtClientId.DisplayName";
+        public const string DynamicHomeBatteryMinSoc_DisplayName = "BaseConfiguration.DynamicHomeBatteryMinSoc.DisplayName";
+        public const string DynamicHomeBatteryMinSoc_HelperText = "BaseConfiguration.DynamicHomeBatteryMinSoc.HelperText";
+        public const string HomeBatteryMinSoc_DisplayName = "BaseConfiguration.HomeBatteryMinSoc.DisplayName";
+        public const string HomeBatteryMinSoc_HelperText = "BaseConfiguration.HomeBatteryMinSoc.HelperText";
+        public const string HomeBatteryMinDynamicMinSoc_HelperText = "BaseConfiguration.HomeBatteryMinDynamicMinSoc.HelperText";
+        public const string HomeBatteryMaxDynamicMinSoc_HelperText = "BaseConfiguration.HomeBatteryMaxDynamicMinSoc.HelperText";
+        public const string DynamicMinSocCalculationBuffer_HelperText = "BaseConfiguration.DynamicMinSocCalculationBuffer.HelperText";
+        public const string ForceFullHomeBatteryBySunset_HelperText = "BaseConfiguration.ForceFullHomeBatteryBySunset.HelperText";
+        public const string HomeBatteryChargingPower_DisplayName = "BaseConfiguration.HomeBatteryChargingPower.DisplayName";
+        public const string HomeBatteryChargingPower_HelperText = "BaseConfiguration.HomeBatteryChargingPower.HelperText";
+        public const string HomeBatteryDischargingPower_DisplayName = "BaseConfiguration.HomeBatteryDischargingPower.DisplayName";
+        public const string HomeBatteryDischargingPower_HelperText = "BaseConfiguration.HomeBatteryDischargingPower.HelperText";
+        public const string HomeBatteryUsableEnergy_DisplayName = "BaseConfiguration.HomeBatteryUsableEnergy.DisplayName";
+        public const string HomeBatteryUsableEnergy_HelperText = "BaseConfiguration.HomeBatteryUsableEnergy.HelperText";
+        public const string DischargeHomeBatteryToMinSocDuringDay_HelperText = "BaseConfiguration.DischargeHomeBatteryToMinSocDuringDay.HelperText";
+        public const string CarChargeLoss_HelperText = "BaseConfiguration.CarChargeLoss.HelperText";
+        public const string MaxCombinedCurrent_DisplayName = "BaseConfiguration.MaxCombinedCurrent.DisplayName";
+        public const string MaxCombinedCurrent_HelperText = "BaseConfiguration.MaxCombinedCurrent.HelperText";
+        public const string MaxInverterAcPower_DisplayName = "BaseConfiguration.MaxInverterAcPower.DisplayName";
+        public const string MaxInverterAcPower_HelperText = "BaseConfiguration.MaxInverterAcPower.HelperText";
+        public const string UseTeslaMateIntegration_DisplayName = "BaseConfiguration.UseTeslaMateIntegration.DisplayName";
+        public const string UseTeslaMateIntegration_HelperText = "BaseConfiguration.UseTeslaMateIntegration.HelperText";
+        public const string UseTeslaMateAsDataSource_DisplayName = "BaseConfiguration.UseTeslaMateAsDataSource.DisplayName";
+        public const string UseTeslaMateAsDataSource_HelperText = "BaseConfiguration.UseTeslaMateAsDataSource.HelperText";
+        public const string HomeGeofenceRadius_DisplayName = "BaseConfiguration.HomeGeofenceRadius.DisplayName";
+        public const string HomeGeofenceRadius_HelperText = "BaseConfiguration.HomeGeofenceRadius.HelperText";
+
+        public static readonly LocalizationKey HomeBatteryPowerInversionUrl_DisplayNameKey = new(HomeBatteryPowerInversionUrl_DisplayName);
+        public static readonly LocalizationKey HomeBatteryPowerInversionUrl_HelperTextKey = new(HomeBatteryPowerInversionUrl_HelperText);
+        public static readonly LocalizationKey UpdateIntervalSeconds_DisplayNameKey = new(UpdateIntervalSeconds_DisplayName);
+        public static readonly LocalizationKey UpdateIntervalSeconds_HelperTextKey = new(UpdateIntervalSeconds_HelperText);
+        public static readonly LocalizationKey SkipPowerChangesOnLastAdjustmentNewerThanSeconds_HelperTextKey = new(SkipPowerChangesOnLastAdjustmentNewerThanSeconds_HelperText);
+        public static readonly LocalizationKey PvValueUpdateIntervalSeconds_DisplayNameKey = new(PvValueUpdateIntervalSeconds_DisplayName);
+        public static readonly LocalizationKey MinutesUntilSwitchOn_DisplayNameKey = new(MinutesUntilSwitchOn_DisplayName);
+        public static readonly LocalizationKey MinutesUntilSwitchOff_DisplayNameKey = new(MinutesUntilSwitchOff_DisplayName);
+        public static readonly LocalizationKey PowerBuffer_DisplayNameKey = new(PowerBuffer_DisplayName);
+        public static readonly LocalizationKey PowerBuffer_HelperTextKey = new(PowerBuffer_HelperText);
+        public static readonly LocalizationKey AllowPowerBufferChangeOnHome_HelperTextKey = new(AllowPowerBufferChangeOnHome_HelperText);
+        public static readonly LocalizationKey PredictSolarPowerGeneration_HelperTextKey = new(PredictSolarPowerGeneration_HelperText);
+        public static readonly LocalizationKey UsePredictedSolarPowerGenerationForChargingSchedules_HelperTextKey = new(UsePredictedSolarPowerGenerationForChargingSchedules_HelperText);
+        public static readonly LocalizationKey ShowEnergyDataOnHome_HelperTextKey = new(ShowEnergyDataOnHome_HelperText);
+        public static readonly LocalizationKey TelegramBotKey_DisplayNameKey = new(TelegramBotKey_DisplayName);
+        public static readonly LocalizationKey TelegramChannelId_DisplayNameKey = new(TelegramChannelId_DisplayName);
+        public static readonly LocalizationKey SendStackTraceToTelegram_HelperTextKey = new(SendStackTraceToTelegram_HelperText);
+        public static readonly LocalizationKey TeslaMateDbServer_DisplayNameKey = new(TeslaMateDbServer_DisplayName);
+        public static readonly LocalizationKey TeslaMateDbPort_DisplayNameKey = new(TeslaMateDbPort_DisplayName);
+        public static readonly LocalizationKey TeslaMateDbPort_HelperTextKey = new(TeslaMateDbPort_HelperText);
+        public static readonly LocalizationKey TeslaMateDbDatabaseName_DisplayNameKey = new(TeslaMateDbDatabaseName_DisplayName);
+        public static readonly LocalizationKey TeslaMateDbUser_DisplayNameKey = new(TeslaMateDbUser_DisplayName);
+        public static readonly LocalizationKey TeslaMateDbPassword_DisplayNameKey = new(TeslaMateDbPassword_DisplayName);
+        public static readonly LocalizationKey MosquitoServer_DisplayNameKey = new(MosquitoServer_DisplayName);
+        public static readonly LocalizationKey MqqtClientId_DisplayNameKey = new(MqqtClientId_DisplayName);
+        public static readonly LocalizationKey DynamicHomeBatteryMinSoc_DisplayNameKey = new(DynamicHomeBatteryMinSoc_DisplayName);
+        public static readonly LocalizationKey DynamicHomeBatteryMinSoc_HelperTextKey = new(DynamicHomeBatteryMinSoc_HelperText);
+        public static readonly LocalizationKey HomeBatteryMinSoc_DisplayNameKey = new(HomeBatteryMinSoc_DisplayName);
+        public static readonly LocalizationKey HomeBatteryMinSoc_HelperTextKey = new(HomeBatteryMinSoc_HelperText);
+        public static readonly LocalizationKey HomeBatteryMinDynamicMinSoc_HelperTextKey = new(HomeBatteryMinDynamicMinSoc_HelperText);
+        public static readonly LocalizationKey HomeBatteryMaxDynamicMinSoc_HelperTextKey = new(HomeBatteryMaxDynamicMinSoc_HelperText);
+        public static readonly LocalizationKey DynamicMinSocCalculationBuffer_HelperTextKey = new(DynamicMinSocCalculationBuffer_HelperText);
+        public static readonly LocalizationKey ForceFullHomeBatteryBySunset_HelperTextKey = new(ForceFullHomeBatteryBySunset_HelperText);
+        public static readonly LocalizationKey HomeBatteryChargingPower_DisplayNameKey = new(HomeBatteryChargingPower_DisplayName);
+        public static readonly LocalizationKey HomeBatteryChargingPower_HelperTextKey = new(HomeBatteryChargingPower_HelperText);
+        public static readonly LocalizationKey HomeBatteryDischargingPower_DisplayNameKey = new(HomeBatteryDischargingPower_DisplayName);
+        public static readonly LocalizationKey HomeBatteryDischargingPower_HelperTextKey = new(HomeBatteryDischargingPower_HelperText);
+        public static readonly LocalizationKey HomeBatteryUsableEnergy_DisplayNameKey = new(HomeBatteryUsableEnergy_DisplayName);
+        public static readonly LocalizationKey HomeBatteryUsableEnergy_HelperTextKey = new(HomeBatteryUsableEnergy_HelperText);
+        public static readonly LocalizationKey DischargeHomeBatteryToMinSocDuringDay_HelperTextKey = new(DischargeHomeBatteryToMinSocDuringDay_HelperText);
+        public static readonly LocalizationKey CarChargeLoss_HelperTextKey = new(CarChargeLoss_HelperText);
+        public static readonly LocalizationKey MaxCombinedCurrent_DisplayNameKey = new(MaxCombinedCurrent_DisplayName);
+        public static readonly LocalizationKey MaxCombinedCurrent_HelperTextKey = new(MaxCombinedCurrent_HelperText);
+        public static readonly LocalizationKey MaxInverterAcPower_DisplayNameKey = new(MaxInverterAcPower_DisplayName);
+        public static readonly LocalizationKey MaxInverterAcPower_HelperTextKey = new(MaxInverterAcPower_HelperText);
+        public static readonly LocalizationKey UseTeslaMateIntegration_DisplayNameKey = new(UseTeslaMateIntegration_DisplayName);
+        public static readonly LocalizationKey UseTeslaMateIntegration_HelperTextKey = new(UseTeslaMateIntegration_HelperText);
+        public static readonly LocalizationKey UseTeslaMateAsDataSource_DisplayNameKey = new(UseTeslaMateAsDataSource_DisplayName);
+        public static readonly LocalizationKey UseTeslaMateAsDataSource_HelperTextKey = new(UseTeslaMateAsDataSource_HelperText);
+        public static readonly LocalizationKey HomeGeofenceRadius_DisplayNameKey = new(HomeGeofenceRadius_DisplayName);
+        public static readonly LocalizationKey HomeGeofenceRadius_HelperTextKey = new(HomeGeofenceRadius_HelperText);
+    }
+
+    public static class NotChargingReasons
+    {
+        public const string CarFullyCharged = "NotChargingReasons.CarFullyCharged";
+        public static readonly LocalizationKey CarFullyChargedKey = new(CarFullyCharged);
+    }
+
+    public static class Components
+    {
+        public static class NotChargingReasons
+        {
+            public const string Heading = "Components.NotChargingReasons.Heading";
+            public const string Remaining = "Components.NotChargingReasons.Remaining";
+            public const string ReasonWithCountdown = "Components.NotChargingReasons.ReasonWithCountdown";
+            public const string NextEnding = "Components.NotChargingReasons.NextEnding";
+
+            public static readonly LocalizationKey HeadingKey = new(Heading);
+            public static readonly LocalizationKey RemainingKey = new(Remaining);
+            public static readonly LocalizationKey ReasonWithCountdownKey = new(ReasonWithCountdown);
+            public static readonly LocalizationKey NextEndingKey = new(NextEnding);
+        }
+    }
+}

--- a/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using TeslaSolarCharger.Shared.Helper;
 using TeslaSolarCharger.Shared.Helper.Contracts;
+using TeslaSolarCharger.Shared.Localization;
 using TeslaSolarCharger.Shared.Resources;
 using TeslaSolarCharger.Shared.Resources.Contracts;
 
@@ -10,6 +11,7 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddSharedDependencies(this IServiceCollection services) =>
         services
+            .AddSingleton<IAppStringLocalizer, AppStringLocalizer>()
             .AddTransient<IStringHelper, StringHelper>()
             .AddTransient<IConstants, Constants>()
             .AddTransient<IValidFromToHelper, ValidFromToHelper>()

--- a/TeslaSolarCharger/Shared/TeslaSolarCharger.Shared.csproj
+++ b/TeslaSolarCharger/Shared/TeslaSolarCharger.Shared.csproj
@@ -32,4 +32,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\TeslaSolarCharger.SharedModel\TeslaSolarCharger.SharedModel.csproj" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add a shared localization service with resource files and strongly typed keys
- migrate configuration labels and helper texts to use localization keys and resources
- localize server-generated reasons and client UI with the new localization service

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build TeslaSolarCharger.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ebada24f088324a8489f45bf80bafd