### PR TITLE
Add localization infrastructure and apply to configuration and reasons

### DIFF
--- a/TeslaSolarCharger/Server/Helper/Contracts/INotChargingWithExpectedPowerReasonHelper.cs
+++ b/TeslaSolarCharger/Server/Helper/Contracts/INotChargingWithExpectedPowerReasonHelper.cs
@@ -1,11 +1,13 @@
-﻿using TeslaSolarCharger.Shared.Dtos.Home;
+using TeslaSolarCharger.Shared.Dtos.Home;
+using TeslaSolarCharger.Shared.Localization;
 
 namespace TeslaSolarCharger.Server.Helper.Contracts;
 
 public interface INotChargingWithExpectedPowerReasonHelper
 {
-    void AddGenericReason(DtoNotChargingWithExpectedPowerReason reason);
-    void AddLoadPointSpecificReason(int? carId, int? connectorId, DtoNotChargingWithExpectedPowerReason reason);
+    void AddGenericReason(LocalizedText reason, params object[] formatArguments);
+
+    void AddLoadPointSpecificReason(int? carId, int? connectorId, LocalizedText reason, DateTimeOffset? reasonEndTime = null, params object[] formatArguments);
 
     Task UpdateReasonsInSettings();
 

--- a/TeslaSolarCharger/Server/Services/ChargingServiceV2.cs
+++ b/TeslaSolarCharger/Server/Services/ChargingServiceV2.cs
@@ -15,6 +15,7 @@ using TeslaSolarCharger.Shared.Dtos.Contracts;
 using TeslaSolarCharger.Shared.Dtos.Home;
 using TeslaSolarCharger.Shared.Dtos.Settings;
 using TeslaSolarCharger.Shared.Enums;
+using TeslaSolarCharger.Shared.Localization.TextCatalog;
 using TeslaSolarCharger.Server.SignalR.Notifiers.Contracts;
 using TeslaSolarCharger.Shared.SignalRClients;
 
@@ -325,7 +326,7 @@ public class ChargingServiceV2 : IChargingServiceV2
         {
             if (!_settings.OcppConnectorStates.ContainsKey(connectorId))
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(null, connectorId, new("OCPP connection not established. After a TSC or charger reboot it can take up to 5 minutes until the charger is connected again."));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(null, connectorId, NotChargingReasonTexts.OcppConnectionNotEstablished);
             }
         }
     }
@@ -336,12 +337,12 @@ public class ChargingServiceV2 : IChargingServiceV2
         {
             if (dtoCar.IsHomeGeofence.Value != true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(dtoCar.Id, null, new("Car is not at home"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(dtoCar.Id, null, NotChargingReasonTexts.CarIsNotAtHome);
             }
 
             if (dtoCar.PluggedIn.Value != true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(dtoCar.Id, null, new("Car is not plugged in"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(dtoCar.Id, null, NotChargingReasonTexts.CarIsNotPluggedIn);
             }
         }
 
@@ -349,7 +350,7 @@ public class ChargingServiceV2 : IChargingServiceV2
         {
             if (!settingsOcppConnectorState.Value.IsPluggedIn.Value)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(null, settingsOcppConnectorState.Key, new("Charging connector is not plugged in"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(null, settingsOcppConnectorState.Key, NotChargingReasonTexts.ChargingConnectorIsNotPluggedIn);
             }
         }
     }

--- a/TeslaSolarCharger/Server/Services/PowerToControlCalculationService.cs
+++ b/TeslaSolarCharger/Server/Services/PowerToControlCalculationService.cs
@@ -6,6 +6,7 @@ using TeslaSolarCharger.Server.Services.Contracts;
 using TeslaSolarCharger.Shared.Contracts;
 using TeslaSolarCharger.Shared.Dtos.Contracts;
 using TeslaSolarCharger.Shared.Dtos.Home;
+using TeslaSolarCharger.Shared.Localization.TextCatalog;
 using TeslaSolarCharger.Shared.Resources.Contracts;
 using TeslaSolarCharger.SharedModel.Enums;
 
@@ -54,7 +55,7 @@ public class PowerToControlCalculationService : IPowerToControlCalculationServic
                 {
                     var dummyPower = chargingLoadPoints.Sum(c => c.ChargingPower);
                     _logger.LogWarning("Use {dummyPower}W as power to control due to too old solar values {pvValuesAge}", dummyPower, pvValuesAge);
-                    notChargingWithExpectedPowerReasonHelper.AddGenericReason(new("Solar values are too old"));
+                    notChargingWithExpectedPowerReasonHelper.AddGenericReason(NotChargingReasonTexts.SolarValuesTooOld);
                     return dummyPower;
                 }
             }
@@ -65,7 +66,8 @@ public class PowerToControlCalculationService : IPowerToControlCalculationServic
         _logger.LogDebug("Adding powerbuffer {powerbuffer}", buffer);
         if (buffer != 0)
         {
-            notChargingWithExpectedPowerReasonHelper.AddGenericReason(new($"Charging speed is {(buffer > 0 ? "decreased" : "increased")} due to power buffer being set to {buffer}W"));
+            var adjustment = buffer > 0 ? NotChargingReasonTexts.Decreased : NotChargingReasonTexts.Increased;
+            notChargingWithExpectedPowerReasonHelper.AddGenericReason(NotChargingReasonTexts.ChargingSpeedAdjustedDueToPowerBuffer, adjustment, buffer);
         }
         var averagedOverage = _settings.Overage ?? _constants.DefaultOverage;
         _logger.LogDebug("Averaged overage {averagedOverage}", averagedOverage);
@@ -196,7 +198,7 @@ public class PowerToControlCalculationService : IPowerToControlCalculationServic
         var homeBatteryMaxChargingPower = _configurationWrapper.HomeBatteryChargingPower();
         if (actualHomeBatterySoc < homeBatteryMinSoc)
         {
-            notChargingWithExpectedPowerReasonHelper.AddGenericReason(new($"Reserved {homeBatteryMaxChargingPower}W for Home battery charging as its SOC ({actualHomeBatterySoc}%) is below minimum SOC ({homeBatteryMinSoc}%)"));
+            notChargingWithExpectedPowerReasonHelper.AddGenericReason(NotChargingReasonTexts.ReservedPowerForHomeBattery, homeBatteryMaxChargingPower ?? 0, actualHomeBatterySoc, homeBatteryMinSoc);
             return homeBatteryMaxChargingPower ?? 0;
         }
 

--- a/TeslaSolarCharger/Shared/Attributes/HelperTextAttribute.cs
+++ b/TeslaSolarCharger/Shared/Attributes/HelperTextAttribute.cs
@@ -1,16 +1,30 @@
-﻿namespace TeslaSolarCharger.Shared.Attributes;
+using System.Globalization;
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Attributes;
 
 public class HelperTextAttribute : Attribute
 {
-    public string HelperText { get; set; }
+    private readonly string _fallbackHelperText;
+    private readonly LocalizedText? _localizedText;
 
     public HelperTextAttribute()
     {
-        HelperText = string.Empty;
+        _fallbackHelperText = string.Empty;
     }
 
     public HelperTextAttribute(string helperText)
     {
-        HelperText = helperText;
+        _fallbackHelperText = helperText ?? string.Empty;
     }
+
+    public HelperTextAttribute(Type localizedTextContainerType, string memberName)
+    {
+        _localizedText = LocalizedTextAccessor.Get(localizedTextContainerType, memberName);
+        _fallbackHelperText = _localizedText.Value.English;
+    }
+
+    public string HelperText => _localizedText?.Translate(CultureInfo.CurrentUICulture) ?? _fallbackHelperText;
+
+    public string GetHelperText(Language language) => _localizedText?.Translate(language) ?? _fallbackHelperText;
 }

--- a/TeslaSolarCharger/Shared/Attributes/LocalizedDisplayNameAttribute.cs
+++ b/TeslaSolarCharger/Shared/Attributes/LocalizedDisplayNameAttribute.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using System.Globalization;
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Attributes;
+
+public sealed class LocalizedDisplayNameAttribute : DisplayNameAttribute
+{
+    private readonly LocalizedText _localizedText;
+
+    public LocalizedDisplayNameAttribute(Type localizedTextContainerType, string memberName)
+        : base(LocalizedTextAccessor.Get(localizedTextContainerType, memberName).English)
+    {
+        _localizedText = LocalizedTextAccessor.Get(localizedTextContainerType, memberName);
+    }
+
+    public override string DisplayName => _localizedText.Translate(CultureInfo.CurrentUICulture);
+
+    public string GetDisplayName(Language language) => _localizedText.Translate(language);
+}

--- a/TeslaSolarCharger/Shared/Dtos/BaseConfiguration/BaseConfigurationBase.cs
+++ b/TeslaSolarCharger/Shared/Dtos/BaseConfiguration/BaseConfigurationBase.cs
@@ -1,6 +1,8 @@
-﻿using System.ComponentModel;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using TeslaSolarCharger.Shared.Attributes;
+using TeslaSolarCharger.Shared.Localization.TextCatalog;
 
 namespace TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
 
@@ -19,8 +21,8 @@ public class BaseConfigurationBase
     public Dictionary<string, string> HomeBatterySocHeaders { get; set; } = new();
     public string? HomeBatteryPowerMqttTopic { get; set; }
     public string? HomeBatteryPowerUrl { get; set; }
-    [DisplayName("HomeBatteryPowerInversion Url")]
-    [HelperText("Use this if you have to dynamically invert the home battery power. Note: Only 0 and 1 are allowed as response. As far as I know this is only needed with Sungrow Inverters.")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryPowerInversionUrl))]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryPowerInversionUrlHelper))]
     public string? HomeBatteryPowerInversionUrl { get; set; }
     public Dictionary<string, string> HomeBatteryPowerHeaders { get; set; } = new();
     public Dictionary<string, string> HomeBatteryPowerInversionHeaders { get; set; } = new();
@@ -32,47 +34,47 @@ public class BaseConfigurationBase
     public Dictionary<string, string> CurrentInverterPowerHeaders { get; set; } = new();
     public bool IsModbusCurrentInverterPowerUrl { get; set; }
     [Required]
-    [DisplayName("Power Change Interval")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UpdateIntervalSeconds))]
     [Postfix("s")]
-    [HelperText("Every x seconds it is checked if any power changes are required.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UpdateIntervalSecondsHelper))]
     public int UpdateIntervalSeconds { get; set; } = 30;
     [Required]
     [Postfix("s")]
-    [HelperText("Be cautious when setting values below 25 seconds as this might result in unexpected bahaviour as cars or charging stations might take some time to update the power.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.SkipPowerChangesOnLastAdjustmentNewerThanSecondsHelper))]
     public int SkipPowerChangesOnLastAdjustmentNewerThanSeconds { get; set; } = 25;
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Solar power refresh interval")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.PvValueUpdateIntervalSeconds))]
     [Postfix("s")]
     public int? PvValueUpdateIntervalSeconds { get; set; } = 1;
     [Required]
     [Range(1, int.MaxValue)]
     [Postfix("s")]
     public int MaxModbusErrorBackoffDuration { get; set; } = 18000;
-    [Required] 
+    [Required]
     public string GeoFence { get; set; } = "Home";
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Time with enough solar power until charging starts")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MinutesUntilSwitchOn))]
     [Postfix("min")]
     public int MinutesUntilSwitchOn { get; set; } = 5;
     [Required]
     [Range(1, int.MaxValue)]
-    [DisplayName("Time without enough solar power until charging stops")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MinutesUntilSwitchOff))]
     [Postfix("min")]
     public int MinutesUntilSwitchOff { get; set; } = 5;
     [Required]
-    [DisplayName("Power Buffer")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.PowerBuffer))]
     [Postfix("W")]
-    [HelperText("Set values higher than 0 to always have some overage (power to grid). Set values lower than 0 to always consume some power from the grid.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.PowerBufferHelper))]
     public int PowerBuffer { get; set; } = 0;
-    [HelperText("If enabled, the configured power buffer is displayed on the home screen, including the option to directly change it.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.AllowPowerBufferChangeOnHomeHelper))]
     public bool AllowPowerBufferChangeOnHome { get; set; }
-    [HelperText("If enabled, your home geofence location is transfered to the Solar4Car.com servers as well as to the servers of www.visualcrossing.com. At no point will your location data be linked with other data.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.PredictSolarPowerGenerationHelper))]
     public bool PredictSolarPowerGeneration { get; set; }
-    [HelperText("If enabled, when a target Soc is set not only grid prices but also estimated solar power generation is used to schedule charging.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UsePredictedSolarPowerGenerationForChargingSchedulesHelper))]
     public bool UsePredictedSolarPowerGenerationForChargingSchedules { get; set; }
-    [HelperText("This is in an early beta and might not behave like expected. Loading might take longer than 30 seconds or never load on low performance devices like Raspery Pi 3. This will be fixed in a future update.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.ShowEnergyDataOnHomeHelper))]
     public bool ShowEnergyDataOnHome { get; set; }
     public string? CurrentPowerToGridJsonPattern { get; set; }
     public decimal CurrentPowerToGridCorrectionFactor { get; set; } = 1;
@@ -82,28 +84,28 @@ public class BaseConfigurationBase
     public decimal HomeBatterySocCorrectionFactor { get; set; } = 1;
     public string? HomeBatteryPowerJsonPattern { get; set; }
     public decimal HomeBatteryPowerCorrectionFactor { get; set; } = 1;
-    [DisplayName("Telegram Bot Key")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.TelegramBotKey))]
     public string? TelegramBotKey { get; set; }
-    [DisplayName("Telegram Channel Id")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.TelegramChannelId))]
     public string? TelegramChannelId { get; set; }
-    [HelperText("If enabled detailed error information are sent via Telegram so developers can find the root cause. This is not needed for normal usage.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.SendStackTraceToTelegramHelper))]
     public bool SendStackTraceToTelegram { get; set; }
-    [DisplayName("TeslaMate Database Host")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.TeslaMateDbServer))]
     public string? TeslaMateDbServer { get; set; }
-    [DisplayName("TeslaMate Database Server Port")]
-    [HelperText("You can use the internal port of the TeslaMate database container")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.TeslaMateDbPort))]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.TeslaMateDbPortHelper))]
     public int? TeslaMateDbPort { get; set; }
-    [DisplayName("TeslaMate Database Name")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.TeslaMateDbDatabaseName))]
     public string? TeslaMateDbDatabaseName { get; set; }
-    [DisplayName("TeslaMate Database Username")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.TeslaMateDbUser))]
     public string? TeslaMateDbUser { get; set; }
     [DataType(DataType.Password)]
-    [DisplayName("TeslaMate Database Server Password")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.TeslaMateDbPassword))]
     public string? TeslaMateDbPassword { get; set; }
-    [DisplayName("Mosquito servername")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MosquitoServer))]
     public string? MosquitoServer { get; set; }
     [Required]
-    [DisplayName("Mqqt ClientId")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MqqtClientId))]
     public string MqqtClientId { get; set; } = "TeslaSolarCharger";
     public string? CurrentPowerToGridXmlPattern { get; set; }
     public string? CurrentPowerToGridXmlAttributeHeaderName { get; set; }
@@ -122,66 +124,63 @@ public class BaseConfigurationBase
     public string? HomeBatteryPowerXmlAttributeHeaderValue { get; set; }
     public string? HomeBatteryPowerXmlAttributeValueName { get; set; }
 
-    [DisplayName("Dynamic Home Battery Min Soc")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.DynamicHomeBatteryMinSoc))]
     [Postfix("%")]
-    [HelperText("If enabled the Home Battery Min Soc is automatically set based on solar predictions to make sure the home battery is fully charged at the end of the day. This setting is only recommended after having solar predictions enabled for at least two weeks.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.DynamicHomeBatteryMinSocHelper))]
     public bool? DynamicHomeBatteryMinSoc { get; set; }
-    [DisplayName("Home Battery Minimum SoC")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryMinSoc))]
     [Postfix("%")]
-    [HelperText("Set the SoC your home battery should get charged to before cars start to use full power. Leave empty if you do not have a home battery")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryMinSocHelper))]
     public int? HomeBatteryMinSoc { get; set; }
     [Postfix("%")]
-    [HelperText("Reserve that is always set as min SoC.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryMinDynamicMinSocHelper))]
     public int HomeBatteryMinDynamicMinSoc { get; set; } = 5;
     [Postfix("%")]
-    [HelperText("Min SoC is never set higher than this value.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryMaxDynamicMinSocHelper))]
     public int HomeBatteryMaxDynamicMinSoc { get; set; } = 95;
     [Postfix("%")]
-    [HelperText("Used to make sure your home battery does not run out of power even if weather predictions are not correct or your house uses more energy than anticipated.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.DynamicMinSocCalculationBufferHelper))]
     public int DynamicMinSocCalculationBuffer { get; set; } = 50;
-    [HelperText("If enabled, the system charges the home battery so it is full by sunset. If disabled, the system only ensures the battery does not run empty before the next sunrise.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.ForceFullHomeBatteryBySunsetHelper))]
     public bool ForceFullHomeBatteryBySunset { get; set; } = true;
-    [DisplayName("Home Battery Target charging power")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryChargingPower))]
     [Postfix("W")]
-    [HelperText(
-        "Set the power your home battery should charge with as long as SoC is below set minimum SoC. Leave empty if you do not have a home battery")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryChargingPowerHelper))]
     public int? HomeBatteryChargingPower { get; set; }
-    [DisplayName("Home Battery target discharging power")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryDischargingPower))]
     [Postfix("W")]
-    [HelperText(
-        "Used to discharge the home battery when option is set in either a charging target or directly at the car.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryDischargingPowerHelper))]
     public int? HomeBatteryDischargingPower { get; set; }
-    [DisplayName("Home Battery Usable energy")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryUsableEnergy))]
     [Postfix("kWh")]
-    [HelperText("Set the usable energy your home battery has.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeBatteryUsableEnergyHelper))]
     public double? HomeBatteryUsableEnergy { get; set; }
-    [HelperText("When enabled TSC discharges the home battery to its Min Soc after sunrise and before sunset. Note: Charging of cars is only started if minimum difference between actual home battery soc and min soc is at least 10%.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.DischargeHomeBatteryToMinSocDuringDayHelper))]
     public bool DischargeHomeBatteryToMinSocDuringDay { get; set; }
     [Postfix("%")]
-    [HelperText("Energy lost when charging cars. Is used to calculate charging schedules based on battery capacity.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.CarChargeLossHelper))]
     public int CarChargeLoss { get; set; } = 15;
-    [DisplayName("Max combined current")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MaxCombinedCurrent))]
     [Postfix("A")]
-    [HelperText("Set a value if you want to reduce the max combined used current per phase of all cars. E.g. if you have two cars each set to max 16A but your installation can only handle 20A per phase you can set 20A here. So if one car uses 16A per phase the other car can only use 4A per phase. Note: Power is distributed based on the set car priorities.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MaxCombinedCurrentHelper))]
     public int? MaxCombinedCurrent { get; set; }
-    [DisplayName("Max Inverter AC Power")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MaxInverterAcPower))]
     [Postfix("W")]
-    [HelperText("If you have a hybrid inverter that has more DC than AC power insert the maximum AC Power here. This is a very rare, so in most cases you can leave this field empty.")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.MaxInverterAcPowerHelper))]
     public int? MaxInverterAcPower { get; set; }
     public string? BleApiBaseUrl { get; set; }
-    [DisplayName("Use TeslaMate Integration")]
-    [HelperText("When you use TeslaMate you can enable this so calculated charging costs from TSC are set in TeslaMate. Note: The charging costs in TeslaMate are only updated ever 24 hours.")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UseTeslaMateIntegration))]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UseTeslaMateIntegrationHelper))]
     public bool UseTeslaMateIntegration { get; set; }
-    [DisplayName("Use TeslaMate as Data Source")]
-    [HelperText("If enabled TeslaMate MQTT is used as datasource. If disabled Tesla API is directly called. Note: If you use TSC without TeslaMate the setting here does not matter. Then the Tesla API is used always.")]
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UseTeslaMateAsDataSource))]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.UseTeslaMateAsDataSourceHelper))]
     public bool UseTeslaMateAsDataSource { get; set; }
-    public double HomeGeofenceLongitude { get; set; } = 13.3761736; //Do not change the default value as depending on this the Geofence from TeslaMate is converted or not
-    public double HomeGeofenceLatitude { get; set; } = 52.5185238; //Do not change the default value as depending on this the Geofence from TeslaMate is converted or not
-    [DisplayName("Home Radius")]
+    public double HomeGeofenceLongitude { get; set; } = 13.3761736;
+    public double HomeGeofenceLatitude { get; set; } = 52.5185238;
+    [LocalizedDisplayName(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeGeofenceRadius))]
     [Postfix("m")]
-    [HelperText("Increase or decrease the radius of the home geofence. Note: Values below 50m are note recommended")]
+    [HelperText(typeof(BaseConfigurationTexts), nameof(BaseConfigurationTexts.HomeGeofenceRadiusHelper))]
     public int HomeGeofenceRadius { get; set; } = 50;
 
     public FrontendConfiguration? FrontendConfiguration { get; set; }
-
 }

--- a/TeslaSolarCharger/Shared/Helper/StringHelper.cs
+++ b/TeslaSolarCharger/Shared/Helper/StringHelper.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using TeslaSolarCharger.Shared.Helper.Contracts;
+using TeslaSolarCharger.Shared.Localization;
 
 namespace TeslaSolarCharger.Shared.Helper;
 
@@ -15,12 +17,18 @@ public class StringHelper(ILogger<StringHelper> logger) : IStringHelper
     public string GenerateFriendlyStringWithOutIdSuffix(string inputString)
     {
         logger.LogTrace("{method}({inputString})", nameof(GenerateFriendlyStringWithOutIdSuffix), inputString);
+
+        if (PropertyLocalizationRegistry.TryGet(inputString, out var propertyText))
+        {
+            return propertyText.Translate(CultureInfo.CurrentUICulture);
+        }
+
         var friendlyString = GenerateFriendlyStringFromPascalString(inputString);
-        if (friendlyString.EndsWith(" Id"))
+        if (friendlyString.EndsWith(" Id", StringComparison.Ordinal))
         {
             return friendlyString[..^3];
         }
-        else if (friendlyString.EndsWith(" Ids"))
+        else if (friendlyString.EndsWith(" Ids", StringComparison.Ordinal))
         {
             return friendlyString[..^4] + "s";
         }
@@ -32,6 +40,17 @@ public class StringHelper(ILogger<StringHelper> logger) : IStringHelper
 
     public string GenerateFriendlyStringFromPascalString(string inputString)
     {
-        return Regex.Replace(inputString, "(\\B[A-Z])", " $1");
+        if (PropertyLocalizationRegistry.TryGet(inputString, out var propertyText))
+        {
+            return propertyText.Translate(CultureInfo.CurrentUICulture);
+        }
+
+        var friendlyString = Regex.Replace(inputString, "(\\B[A-Z])", " $1");
+        if (LocalizedTextRegistry.TryGet(friendlyString, out var localizedText))
+        {
+            return localizedText.Translate(CultureInfo.CurrentUICulture);
+        }
+
+        return friendlyString;
     }
 }

--- a/TeslaSolarCharger/Shared/Localization/CurrentCultureTextLocalizer.cs
+++ b/TeslaSolarCharger/Shared/Localization/CurrentCultureTextLocalizer.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using System.Linq;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+public class CurrentCultureTextLocalizer : ITextLocalizer
+{
+    public Language Language => CultureInfo.CurrentUICulture.TwoLetterISOLanguageName switch
+    {
+        "de" => Language.German,
+        _ => Language.English,
+    };
+
+    public string Translate(LocalizedText text) => text.Translate(CultureInfo.CurrentUICulture);
+
+    public string Translate(string englishKey) => LocalizedTextRegistry.Translate(englishKey, CultureInfo.CurrentUICulture);
+
+    public string Format(LocalizedText text, params object[] formatArguments)
+    {
+        var translatedArguments = formatArguments.Select(argument => argument switch
+        {
+            LocalizedText localizedText => Translate(localizedText),
+            IFormattable formattable => formattable.ToString(null, CultureInfo.CurrentUICulture),
+            _ => argument?.ToString() ?? string.Empty,
+        }).ToArray();
+
+        var template = Translate(text);
+        return string.Format(CultureInfo.CurrentUICulture, template, translatedArguments);
+    }
+}

--- a/TeslaSolarCharger/Shared/Localization/ITextLocalizer.cs
+++ b/TeslaSolarCharger/Shared/Localization/ITextLocalizer.cs
@@ -1,0 +1,12 @@
+namespace TeslaSolarCharger.Shared.Localization;
+
+public interface ITextLocalizer
+{
+    Language Language { get; }
+
+    string Translate(LocalizedText text);
+
+    string Translate(string englishKey);
+
+    string Format(LocalizedText text, params object[] formatArguments);
+}

--- a/TeslaSolarCharger/Shared/Localization/Language.cs
+++ b/TeslaSolarCharger/Shared/Localization/Language.cs
@@ -1,0 +1,7 @@
+namespace TeslaSolarCharger.Shared.Localization;
+
+public enum Language
+{
+    English,
+    German,
+}

--- a/TeslaSolarCharger/Shared/Localization/LocalizedText.cs
+++ b/TeslaSolarCharger/Shared/Localization/LocalizedText.cs
@@ -1,0 +1,50 @@
+using System.Globalization;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+public readonly record struct LocalizedText
+{
+    public LocalizedText()
+    {
+        throw new InvalidOperationException("Use LocalizedTextFactory to create instances of LocalizedText.");
+    }
+
+    internal LocalizedText(string english, string german, string? propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(english))
+        {
+            throw new ArgumentException("English text must be provided.", nameof(english));
+        }
+
+        if (string.IsNullOrWhiteSpace(german))
+        {
+            throw new ArgumentException("German text must be provided.", nameof(german));
+        }
+
+        Key = english;
+        German = german;
+        PropertyName = propertyName;
+    }
+
+    public string Key { get; }
+
+    public string English => Key;
+
+    public string German { get; }
+
+    public string? PropertyName { get; }
+
+    public string Translate(CultureInfo culture) => culture.TwoLetterISOLanguageName switch
+    {
+        "de" => German,
+        _ => English,
+    };
+
+    public string Translate(Language language) => language switch
+    {
+        Language.German => German,
+        _ => English,
+    };
+
+    public override string ToString() => English;
+}

--- a/TeslaSolarCharger/Shared/Localization/LocalizedTextAccessor.cs
+++ b/TeslaSolarCharger/Shared/Localization/LocalizedTextAccessor.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+public static class LocalizedTextAccessor
+{
+    public static LocalizedText Get(Type containerType, string memberName)
+    {
+        if (containerType == null)
+        {
+            throw new ArgumentNullException(nameof(containerType));
+        }
+
+        if (string.IsNullOrWhiteSpace(memberName))
+        {
+            throw new ArgumentException("Member name must be provided.", nameof(memberName));
+        }
+
+        var member = (MemberInfo?)containerType.GetProperty(memberName, BindingFlags.Public | BindingFlags.Static)
+            ?? containerType.GetField(memberName, BindingFlags.Public | BindingFlags.Static);
+
+        if (member == null)
+        {
+            throw new InvalidOperationException($"No public static member named '{memberName}' found on '{containerType.FullName}'.");
+        }
+
+        var value = member switch
+        {
+            PropertyInfo propertyInfo => propertyInfo.GetValue(null),
+            FieldInfo fieldInfo => fieldInfo.GetValue(null),
+            _ => null,
+        };
+
+        if (value is LocalizedText localizedText)
+        {
+            return localizedText;
+        }
+
+        throw new InvalidOperationException($"Member '{memberName}' on '{containerType.FullName}' does not provide a LocalizedText.");
+    }
+}

--- a/TeslaSolarCharger/Shared/Localization/LocalizedTextFactory.cs
+++ b/TeslaSolarCharger/Shared/Localization/LocalizedTextFactory.cs
@@ -1,0 +1,22 @@
+using System.Linq.Expressions;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+public static class LocalizedTextFactory
+{
+    public static LocalizedText Create(string english, string german)
+    {
+        var localizedText = new LocalizedText(english, german, null);
+        LocalizedTextRegistry.Register(localizedText);
+        return localizedText;
+    }
+
+    public static LocalizedText CreateForProperty<T>(Expression<Func<T, object?>> property, string english, string german)
+    {
+        var propertyName = PropertyExpressionHelper.GetPropertyName(property);
+        var localizedText = new LocalizedText(english, german, propertyName);
+        LocalizedTextRegistry.Register(localizedText);
+        PropertyLocalizationRegistry.Register(propertyName, localizedText);
+        return localizedText;
+    }
+}

--- a/TeslaSolarCharger/Shared/Localization/LocalizedTextRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/LocalizedTextRegistry.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+public static class LocalizedTextRegistry
+{
+    private static readonly ConcurrentDictionary<string, LocalizedText> Texts = new(StringComparer.Ordinal);
+
+    public static void Register(LocalizedText text)
+    {
+        var existing = Texts.AddOrUpdate(text.Key, text, (_, current) =>
+        {
+            if (current != text)
+            {
+                throw new InvalidOperationException($"Localized text for '{text.Key}' is already registered with different translations.");
+            }
+
+            return current;
+        });
+
+        if (existing != text && existing.Key != text.Key)
+        {
+            throw new InvalidOperationException($"Unable to register localized text for '{text.Key}'.");
+        }
+    }
+
+    public static bool TryGet(string englishKey, out LocalizedText text) => Texts.TryGetValue(englishKey, out text);
+
+    public static string Translate(string englishKey, CultureInfo culture) =>
+        TryGet(englishKey, out var localizedText)
+            ? localizedText.Translate(culture)
+            : englishKey;
+}

--- a/TeslaSolarCharger/Shared/Localization/PropertyExpressionHelper.cs
+++ b/TeslaSolarCharger/Shared/Localization/PropertyExpressionHelper.cs
@@ -1,0 +1,32 @@
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+internal static class PropertyExpressionHelper
+{
+    public static string GetPropertyName<T>(Expression<Func<T, object?>> expression)
+    {
+        if (expression.Body is MemberExpression memberExpression)
+        {
+            return ValidateMember(memberExpression.Member);
+        }
+
+        if (expression.Body is UnaryExpression { Operand: MemberExpression innerMember })
+        {
+            return ValidateMember(innerMember.Member);
+        }
+
+        throw new ArgumentException("Expression must reference a property.", nameof(expression));
+    }
+
+    private static string ValidateMember(MemberInfo memberInfo)
+    {
+        if (memberInfo is PropertyInfo propertyInfo)
+        {
+            return propertyInfo.Name;
+        }
+
+        throw new ArgumentException("Expression must reference a property.");
+    }
+}

--- a/TeslaSolarCharger/Shared/Localization/PropertyLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/PropertyLocalizationRegistry.cs
@@ -1,0 +1,29 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+public static class PropertyLocalizationRegistry
+{
+    private static readonly ConcurrentDictionary<string, LocalizedText> PropertyTexts = new(StringComparer.Ordinal);
+
+    public static void Register(string propertyName, LocalizedText text)
+    {
+        PropertyTexts.AddOrUpdate(propertyName, text, (_, current) =>
+        {
+            if (current != text)
+            {
+                throw new InvalidOperationException($"A different translation for property '{propertyName}' is already registered.");
+            }
+
+            return current;
+        });
+    }
+
+    public static bool TryGet(string propertyName, out LocalizedText text) => PropertyTexts.TryGetValue(propertyName, out text);
+
+    public static string Translate(string propertyName, CultureInfo culture) =>
+        TryGet(propertyName, out var text)
+            ? text.Translate(culture)
+            : propertyName;
+}

--- a/TeslaSolarCharger/Shared/Localization/TextCatalog/BaseConfigurationTexts.cs
+++ b/TeslaSolarCharger/Shared/Localization/TextCatalog/BaseConfigurationTexts.cs
@@ -1,0 +1,365 @@
+using TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Localization.TextCatalog;
+
+public static class BaseConfigurationTexts
+{
+    public static LocalizedText SolarMqttServer { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.SolarMqttServer, "Solar MQTT Server", "Solar-MQTT-Server");
+
+    public static LocalizedText SolarMqttUserName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.SolarMqttUserName, "Solar MQTT user name", "Solar-MQTT-Benutzername");
+
+    public static LocalizedText SolarMqttPassword { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.SolarMqttPassword, "Solar MQTT password", "Solar-MQTT-Passwort");
+
+    public static LocalizedText CurrentPowerToGridMqttTopic { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridMqttTopic, "Grid export MQTT topic", "MQTT-Thema für Netzeinspeisung");
+
+    public static LocalizedText CurrentPowerToGridUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridUrl, "Grid export URL", "URL für Netzeinspeisung");
+
+    public static LocalizedText CurrentPowerToGridHeaders { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridHeaders, "Grid export headers", "Header für Netzeinspeisung");
+
+    public static LocalizedText HomeBatterySocMqttTopic { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocMqttTopic, "Home battery SoC MQTT topic", "MQTT-Thema für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatterySocUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocUrl, "Home battery SoC URL", "URL für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatterySocHeaders { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocHeaders, "Home battery SoC headers", "Header für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatteryPowerMqttTopic { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerMqttTopic, "Home battery power MQTT topic", "MQTT-Thema für Heimbatterieleistung");
+
+    public static LocalizedText HomeBatteryPowerUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerUrl, "Home battery power URL", "URL für Heimbatterieleistung");
+
+    public static LocalizedText HomeBatteryPowerInversionUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerInversionUrl, "Home battery power inversion URL", "URL zur Invertierung der Heimbatterieleistung");
+
+    public static LocalizedText HomeBatteryPowerInversionUrlHelper { get; } =
+        LocalizedTextFactory.Create("Use this if you have to dynamically invert the home battery power. Note: Only 0 and 1 are allowed as response. As far as I know this is only needed with Sungrow Inverters.",
+            "Verwende diese URL, wenn die Heimbatterieleistung dynamisch invertiert werden muss. Hinweis: Als Antwort sind nur 0 und 1 erlaubt. Nach aktuellem Wissen ist dies nur bei Sungrow-Wechselrichtern erforderlich.");
+
+    public static LocalizedText HomeBatteryPowerHeaders { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerHeaders, "Home battery power headers", "Header für Heimbatterieleistung");
+
+    public static LocalizedText HomeBatteryPowerInversionHeaders { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerInversionHeaders, "Home battery power inversion headers", "Header für invertierte Heimbatterieleistung");
+
+    public static LocalizedText IsModbusGridUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.IsModbusGridUrl, "Grid data via Modbus", "Netzdaten über Modbus");
+
+    public static LocalizedText IsModbusHomeBatterySocUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.IsModbusHomeBatterySocUrl, "Home battery SoC via Modbus", "Heimbatterie-SoC über Modbus");
+
+    public static LocalizedText IsModbusHomeBatteryPowerUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.IsModbusHomeBatteryPowerUrl, "Home battery power via Modbus", "Heimbatterieleistung über Modbus");
+
+    public static LocalizedText CurrentInverterPowerMqttTopic { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerMqttTopic, "Inverter power MQTT topic", "MQTT-Thema für Wechselrichterleistung");
+
+    public static LocalizedText CurrentInverterPowerUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerUrl, "Inverter power URL", "URL für Wechselrichterleistung");
+
+    public static LocalizedText CurrentInverterPowerHeaders { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerHeaders, "Inverter power headers", "Header für Wechselrichterleistung");
+
+    public static LocalizedText IsModbusCurrentInverterPowerUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.IsModbusCurrentInverterPowerUrl, "Inverter power via Modbus", "Wechselrichterleistung über Modbus");
+
+    public static LocalizedText UpdateIntervalSeconds { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.UpdateIntervalSeconds, "Power change interval", "Intervall für Leistungsänderungen");
+
+    public static LocalizedText UpdateIntervalSecondsHelper { get; } =
+        LocalizedTextFactory.Create("Every x seconds it is checked if any power changes are required.",
+            "In diesem Intervall wird geprüft, ob Leistungsanpassungen erforderlich sind.");
+
+    public static LocalizedText SkipPowerChangesOnLastAdjustmentNewerThanSeconds { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.SkipPowerChangesOnLastAdjustmentNewerThanSeconds, "Ignore changes if the last adjustment is newer than", "Änderungen ignorieren, wenn die letzte Anpassung neuer ist als");
+
+    public static LocalizedText SkipPowerChangesOnLastAdjustmentNewerThanSecondsHelper { get; } =
+        LocalizedTextFactory.Create("Be cautious when setting values below 25 seconds as this might result in unexpected bahaviour as cars or charging stations might take some time to update the power.",
+            "Werte unter 25 Sekunden können zu unerwartetem Verhalten führen, da Fahrzeuge oder Ladestationen etwas Zeit für die Aktualisierung der Leistung benötigen.");
+
+    public static LocalizedText PvValueUpdateIntervalSeconds { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.PvValueUpdateIntervalSeconds, "Solar power refresh interval", "Aktualisierungsintervall für Solarleistung");
+
+    public static LocalizedText MaxModbusErrorBackoffDuration { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.MaxModbusErrorBackoffDuration, "Maximum Modbus error backoff", "Maximale Modbus-Fehlerrückfallzeit");
+
+    public static LocalizedText GeoFence { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.GeoFence, "Home geofence", "Heim-Geofence");
+
+    public static LocalizedText MinutesUntilSwitchOn { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.MinutesUntilSwitchOn, "Time with enough solar power until charging starts", "Dauer mit ausreichender Solarleistung bis der Ladevorgang startet");
+
+    public static LocalizedText MinutesUntilSwitchOff { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.MinutesUntilSwitchOff, "Time without enough solar power until charging stops", "Dauer ohne ausreichende Solarleistung bis der Ladevorgang stoppt");
+
+    public static LocalizedText PowerBuffer { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.PowerBuffer, "Power buffer", "Leistungspuffer");
+
+    public static LocalizedText PowerBufferHelper { get; } =
+        LocalizedTextFactory.Create("Set values higher than 0 to always have some overage (power to grid). Set values lower than 0 to always consume some power from the grid.",
+            "Werte über 0 sorgen stets für eine Einspeisung ins Netz. Werte unter 0 führen dazu, dass immer etwas Netzleistung bezogen wird.");
+
+    public static LocalizedText AllowPowerBufferChangeOnHome { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.AllowPowerBufferChangeOnHome, "Allow power buffer change on home screen", "Änderung des Leistungspuffers auf der Startseite erlauben");
+
+    public static LocalizedText AllowPowerBufferChangeOnHomeHelper { get; } =
+        LocalizedTextFactory.Create("If enabled, the configured power buffer is displayed on the home screen, including the option to directly change it.",
+            "Ist diese Option aktiv, wird der eingestellte Leistungspuffer auf der Startseite angezeigt und kann dort direkt geändert werden.");
+
+    public static LocalizedText PredictSolarPowerGeneration { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.PredictSolarPowerGeneration, "Share geofence for solar prediction", "Geofence für Solarprognose teilen");
+
+    public static LocalizedText PredictSolarPowerGenerationHelper { get; } =
+        LocalizedTextFactory.Create("If enabled, your home geofence location is transfered to the Solar4Car.com servers as well as to the servers of www.visualcrossing.com. At no point will your location data be linked with other data.",
+            "Wenn aktiviert, werden die Koordinaten des Heim-Geofence an die Server von Solar4Car.com sowie www.visualcrossing.com übertragen. Die Standortdaten werden niemals mit anderen Daten verknüpft.");
+
+    public static LocalizedText UsePredictedSolarPowerGenerationForChargingSchedules { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.UsePredictedSolarPowerGenerationForChargingSchedules, "Use solar prediction for charging schedules", "Solarprognose für Ladepläne verwenden");
+
+    public static LocalizedText UsePredictedSolarPowerGenerationForChargingSchedulesHelper { get; } =
+        LocalizedTextFactory.Create("If enabled, when a target Soc is set not only grid prices but also estimated solar power generation is used to schedule charging.",
+            "Wenn aktiviert, werden bei gesetztem Ziel-SoC neben den Netzpreisen auch die prognostizierten Solarleistungen für die Ladeplanung berücksichtigt.");
+
+    public static LocalizedText ShowEnergyDataOnHome { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.ShowEnergyDataOnHome, "Show energy data on home screen", "Energiedaten auf der Startseite anzeigen");
+
+    public static LocalizedText ShowEnergyDataOnHomeHelper { get; } =
+        LocalizedTextFactory.Create("This is in an early beta and might not behave like expected. Loading might take longer than 30 seconds or never load on low performance devices like Raspery Pi 3. This will be fixed in a future update.",
+            "Diese Funktion befindet sich in einer frühen Beta-Phase und kann sich unerwartet verhalten. Das Laden kann länger als 30 Sekunden dauern oder auf leistungsschwachen Geräten wie dem Raspberry Pi 3 fehlschlagen. Dies wird in einem zukünftigen Update verbessert.");
+
+    public static LocalizedText CurrentPowerToGridJsonPattern { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridJsonPattern, "Grid export JSON path", "JSON-Pfad für Netzeinspeisung");
+
+    public static LocalizedText CurrentPowerToGridCorrectionFactor { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridCorrectionFactor, "Grid export correction factor", "Korrekturfaktor für Netzeinspeisung");
+
+    public static LocalizedText CurrentInverterPowerJsonPattern { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerJsonPattern, "Inverter power JSON path", "JSON-Pfad für Wechselrichterleistung");
+
+    public static LocalizedText CurrentInverterPowerCorrectionFactor { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerCorrectionFactor, "Inverter power correction factor", "Korrekturfaktor für Wechselrichterleistung");
+
+    public static LocalizedText HomeBatterySocJsonPattern { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocJsonPattern, "Home battery SoC JSON path", "JSON-Pfad für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatterySocCorrectionFactor { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocCorrectionFactor, "Home battery SoC correction factor", "Korrekturfaktor für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatteryPowerJsonPattern { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerJsonPattern, "Home battery power JSON path", "JSON-Pfad für Heimbatterieleistung");
+
+    public static LocalizedText HomeBatteryPowerCorrectionFactor { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerCorrectionFactor, "Home battery power correction factor", "Korrekturfaktor für Heimbatterieleistung");
+
+    public static LocalizedText TelegramBotKey { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.TelegramBotKey, "Telegram bot key", "Telegram-Bot-Schlüssel");
+
+    public static LocalizedText TelegramChannelId { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.TelegramChannelId, "Telegram channel ID", "Telegram-Kanal-ID");
+
+    public static LocalizedText SendStackTraceToTelegram { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.SendStackTraceToTelegram, "Send stack traces to Telegram", "Stacktraces an Telegram senden");
+
+    public static LocalizedText SendStackTraceToTelegramHelper { get; } =
+        LocalizedTextFactory.Create("If enabled detailed error information are sent via Telegram so developers can find the root cause. This is not needed for normal usage.",
+            "Wenn aktiviert, werden detaillierte Fehlermeldungen über Telegram gesendet, damit Entwickler die Ursache finden können. Für den normalen Betrieb ist dies nicht erforderlich.");
+
+    public static LocalizedText TeslaMateDbServer { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.TeslaMateDbServer, "TeslaMate database host", "TeslaMate-Datenbankserver");
+
+    public static LocalizedText TeslaMateDbPort { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.TeslaMateDbPort, "TeslaMate database server port", "Port des TeslaMate-Datenbankservers");
+
+    public static LocalizedText TeslaMateDbPortHelper { get; } =
+        LocalizedTextFactory.Create("You can use the internal port of the TeslaMate database container", "Du kannst den internen Port des TeslaMate-Datenbankcontainers verwenden.");
+
+    public static LocalizedText TeslaMateDbDatabaseName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.TeslaMateDbDatabaseName, "TeslaMate database name", "TeslaMate-Datenbankname");
+
+    public static LocalizedText TeslaMateDbUser { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.TeslaMateDbUser, "TeslaMate database username", "TeslaMate-Datenbankbenutzer");
+
+    public static LocalizedText TeslaMateDbPassword { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.TeslaMateDbPassword, "TeslaMate database password", "TeslaMate-Datenbankpasswort");
+
+    public static LocalizedText MosquitoServer { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.MosquitoServer, "Mosquitto server name", "Mosquitto-Servername");
+
+    public static LocalizedText MqqtClientId { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.MqqtClientId, "MQTT client ID", "MQTT-Client-ID");
+
+    public static LocalizedText CurrentPowerToGridXmlPattern { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridXmlPattern, "Grid export XML path", "XML-Pfad für Netzeinspeisung");
+
+    public static LocalizedText CurrentPowerToGridXmlAttributeHeaderName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridXmlAttributeHeaderName, "Grid export XML header name", "XML-Headername für Netzeinspeisung");
+
+    public static LocalizedText CurrentPowerToGridXmlAttributeHeaderValue { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridXmlAttributeHeaderValue, "Grid export XML header value", "XML-Headerwert für Netzeinspeisung");
+
+    public static LocalizedText CurrentPowerToGridXmlAttributeValueName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentPowerToGridXmlAttributeValueName, "Grid export XML value name", "XML-Wertename für Netzeinspeisung");
+
+    public static LocalizedText CurrentInverterPowerXmlPattern { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerXmlPattern, "Inverter power XML path", "XML-Pfad für Wechselrichterleistung");
+
+    public static LocalizedText CurrentInverterPowerXmlAttributeHeaderName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerXmlAttributeHeaderName, "Inverter power XML header name", "XML-Headername für Wechselrichterleistung");
+
+    public static LocalizedText CurrentInverterPowerXmlAttributeHeaderValue { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerXmlAttributeHeaderValue, "Inverter power XML header value", "XML-Headerwert für Wechselrichterleistung");
+
+    public static LocalizedText CurrentInverterPowerXmlAttributeValueName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CurrentInverterPowerXmlAttributeValueName, "Inverter power XML value name", "XML-Wertename für Wechselrichterleistung");
+
+    public static LocalizedText HomeBatterySocXmlPattern { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocXmlPattern, "Home battery SoC XML path", "XML-Pfad für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatterySocXmlAttributeHeaderName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocXmlAttributeHeaderName, "Home battery SoC XML header name", "XML-Headername für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatterySocXmlAttributeHeaderValue { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocXmlAttributeHeaderValue, "Home battery SoC XML header value", "XML-Headerwert für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatterySocXmlAttributeValueName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatterySocXmlAttributeValueName, "Home battery SoC XML value name", "XML-Wertename für Heimbatterie-SoC");
+
+    public static LocalizedText HomeBatteryPowerXmlPattern { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerXmlPattern, "Home battery power XML path", "XML-Pfad für Heimbatterieleistung");
+
+    public static LocalizedText HomeBatteryPowerXmlAttributeHeaderName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerXmlAttributeHeaderName, "Home battery power XML header name", "XML-Headername für Heimbatterieleistung");
+
+    public static LocalizedText HomeBatteryPowerXmlAttributeHeaderValue { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerXmlAttributeHeaderValue, "Home battery power XML header value", "XML-Headerwert für Heimbatterieleistung");
+
+    public static LocalizedText HomeBatteryPowerXmlAttributeValueName { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryPowerXmlAttributeValueName, "Home battery power XML value name", "XML-Wertename für Heimbatterieleistung");
+
+    public static LocalizedText DynamicHomeBatteryMinSoc { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.DynamicHomeBatteryMinSoc, "Dynamic home battery minimum SoC", "Dynamisches Mindest-SoC der Heimbatterie");
+
+    public static LocalizedText DynamicHomeBatteryMinSocHelper { get; } =
+        LocalizedTextFactory.Create("If enabled the Home Battery Min Soc is automatically set based on solar predictions to make sure the home battery is fully charged at the end of the day. This setting is only recommended after having solar predictions enabled for at least two weeks.",
+            "Wenn aktiviert, wird das Mindest-SoC der Heimbatterie anhand der Solarprognosen automatisch so eingestellt, dass die Batterie zum Tagesende voll ist. Diese Einstellung wird erst nach mindestens zwei Wochen mit aktivierter Solarprognose empfohlen.");
+
+    public static LocalizedText HomeBatteryMinSoc { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryMinSoc, "Home battery minimum SoC", "Mindest-SoC der Heimbatterie");
+
+    public static LocalizedText HomeBatteryMinSocHelper { get; } =
+        LocalizedTextFactory.Create("Set the SoC your home battery should get charged to before cars start to use full power. Leave empty if you do not have a home battery",
+            "Lege fest, bis zu welchem SoC die Heimbatterie geladen werden soll, bevor Fahrzeuge die volle Leistung nutzen. Leer lassen, wenn keine Heimbatterie vorhanden ist.");
+
+    public static LocalizedText HomeBatteryMinDynamicMinSoc { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryMinDynamicMinSoc, "Dynamic minimum SoC reserve", "Dynamische Mindest-SoC-Reserve");
+
+    public static LocalizedText HomeBatteryMinDynamicMinSocHelper { get; } =
+        LocalizedTextFactory.Create("Reserve that is always set as min SoC.", "Reserve, die stets als Mindest-SoC gesetzt wird.");
+
+    public static LocalizedText HomeBatteryMaxDynamicMinSoc { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryMaxDynamicMinSoc, "Maximum dynamic minimum SoC", "Maximaler dynamischer Mindest-SoC");
+
+    public static LocalizedText HomeBatteryMaxDynamicMinSocHelper { get; } =
+        LocalizedTextFactory.Create("Min SoC is never set higher than this value.", "Das Mindest-SoC wird niemals höher als dieser Wert gesetzt.");
+
+    public static LocalizedText DynamicMinSocCalculationBuffer { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.DynamicMinSocCalculationBuffer, "Dynamic SoC calculation buffer", "Puffer für dynamische SoC-Berechnung");
+
+    public static LocalizedText DynamicMinSocCalculationBufferHelper { get; } =
+        LocalizedTextFactory.Create("Used to make sure your home battery does not run out of power even if weather predictions are not correct or your house uses more energy than anticipated.",
+            "Stellt sicher, dass die Heimbatterie nicht leer läuft, selbst wenn Wetterprognosen ungenau sind oder der Stromverbrauch höher als erwartet ist.");
+
+    public static LocalizedText ForceFullHomeBatteryBySunset { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.ForceFullHomeBatteryBySunset, "Charge home battery to full by sunset", "Heimbatterie bis Sonnenuntergang vollständig laden");
+
+    public static LocalizedText ForceFullHomeBatteryBySunsetHelper { get; } =
+        LocalizedTextFactory.Create("If enabled, the system charges the home battery so it is full by sunset. If disabled, the system only ensures the battery does not run empty before the next sunrise.",
+            "Wenn aktiviert, lädt das System die Heimbatterie bis zum Sonnenuntergang vollständig. Andernfalls wird nur sichergestellt, dass die Batterie vor dem nächsten Sonnenaufgang nicht leerläuft.");
+
+    public static LocalizedText HomeBatteryChargingPower { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryChargingPower, "Home battery target charging power", "Ziel-Ladeleistung der Heimbatterie");
+
+    public static LocalizedText HomeBatteryChargingPowerHelper { get; } =
+        LocalizedTextFactory.Create("Set the power your home battery should charge with as long as SoC is below set minimum SoC. Leave empty if you do not have a home battery",
+            "Lege fest, mit welcher Leistung die Heimbatterie geladen werden soll, solange das SoC unter dem Mindestwert liegt. Leer lassen, wenn keine Heimbatterie vorhanden ist.");
+
+    public static LocalizedText HomeBatteryDischargingPower { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryDischargingPower, "Home battery target discharging power", "Ziel-Entladeleistung der Heimbatterie");
+
+    public static LocalizedText HomeBatteryDischargingPowerHelper { get; } =
+        LocalizedTextFactory.Create("Used to discharge the home battery when option is set in either a charging target or directly at the car.",
+            "Wird verwendet, um die Heimbatterie zu entladen, wenn dies in einem Ladeziel oder direkt am Fahrzeug eingestellt ist.");
+
+    public static LocalizedText HomeBatteryUsableEnergy { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeBatteryUsableEnergy, "Home battery usable energy", "Nutzbare Energie der Heimbatterie");
+
+    public static LocalizedText HomeBatteryUsableEnergyHelper { get; } =
+        LocalizedTextFactory.Create("Set the usable energy your home battery has.", "Lege die nutzbare Energie deiner Heimbatterie fest.");
+
+    public static LocalizedText DischargeHomeBatteryToMinSocDuringDay { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.DischargeHomeBatteryToMinSocDuringDay, "Discharge home battery to minimum during the day", "Heimbatterie tagsüber auf Mindest-SoC entladen");
+
+    public static LocalizedText DischargeHomeBatteryToMinSocDuringDayHelper { get; } =
+        LocalizedTextFactory.Create("When enabled TSC discharges the home battery to its Min Soc after sunrise and before sunset. Note: Charging of cars is only started if minimum difference between actual home battery soc and min soc is at least 10%.",
+            "Wenn aktiviert, entlädt TSC die Heimbatterie nach Sonnenaufgang und vor Sonnenuntergang auf das Mindest-SoC. Hinweis: Fahrzeuge werden nur geladen, wenn der Unterschied zwischen aktuellem und Mindest-SoC mindestens 10 % beträgt.");
+
+    public static LocalizedText CarChargeLoss { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.CarChargeLoss, "Car charging losses", "Ladeverluste des Fahrzeugs");
+
+    public static LocalizedText CarChargeLossHelper { get; } =
+        LocalizedTextFactory.Create("Energy lost when charging cars. Is used to calculate charging schedules based on battery capacity.",
+            "Energieverlust beim Laden von Fahrzeugen. Wird verwendet, um Ladepläne basierend auf der Batteriekapazität zu berechnen.");
+
+    public static LocalizedText MaxCombinedCurrent { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.MaxCombinedCurrent, "Max combined current", "Maximaler Gesamtstrom");
+
+    public static LocalizedText MaxCombinedCurrentHelper { get; } =
+        LocalizedTextFactory.Create("Set a value if you want to reduce the max combined used current per phase of all cars. E.g. if you have two cars each set to max 16A but your installation can only handle 20A per phase you can set 20A here. So if one car uses 16A per phase the other car can only use 4A per phase. Note: Power is distributed based on the set car priorities.",
+            "Lege einen Wert fest, um den maximalen Gesamtstrom pro Phase aller Fahrzeuge zu begrenzen. Beispiel: Haben zwei Fahrzeuge jeweils 16 A, deine Installation erlaubt aber nur 20 A pro Phase, kannst du hier 20 A setzen. Nutzt ein Fahrzeug 16 A, bleiben dem anderen 4 A. Hinweis: Die Leistung wird basierend auf den Fahrzeugprioritäten verteilt.");
+
+    public static LocalizedText MaxInverterAcPower { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.MaxInverterAcPower, "Max inverter AC power", "Maximale Wechselrichter-AC-Leistung");
+
+    public static LocalizedText MaxInverterAcPowerHelper { get; } =
+        LocalizedTextFactory.Create("If you have a hybrid inverter that has more DC than AC power insert the maximum AC Power here. This is a very rare, so in most cases you can leave this field empty.",
+            "Wenn du einen Hybrid-Wechselrichter mit höherer DC- als AC-Leistung hast, gib hier die maximale AC-Leistung an. Dies ist sehr selten, daher kann das Feld in den meisten Fällen leer bleiben.");
+
+    public static LocalizedText BleApiBaseUrl { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.BleApiBaseUrl, "BLE API base URL", "Basis-URL der BLE-API");
+
+    public static LocalizedText UseTeslaMateIntegration { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.UseTeslaMateIntegration, "Use TeslaMate integration", "TeslaMate-Integration verwenden");
+
+    public static LocalizedText UseTeslaMateIntegrationHelper { get; } =
+        LocalizedTextFactory.Create("When you use TeslaMate you can enable this so calculated charging costs from TSC are set in TeslaMate. Note: The charging costs in TeslaMate are only updated ever 24 hours.",
+            "Wenn du TeslaMate verwendest, kannst du dies aktivieren, damit TSC die berechneten Ladekosten in TeslaMate überträgt. Hinweis: Die Kosten werden in TeslaMate nur alle 24 Stunden aktualisiert.");
+
+    public static LocalizedText UseTeslaMateAsDataSource { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.UseTeslaMateAsDataSource, "Use TeslaMate as data source", "TeslaMate als Datenquelle verwenden");
+
+    public static LocalizedText UseTeslaMateAsDataSourceHelper { get; } =
+        LocalizedTextFactory.Create("If enabled TeslaMate MQTT is used as datasource. If disabled Tesla API is directly called. Note: If you use TSC without TeslaMate the setting here does not matter. Then the Tesla API is used always.",
+            "Wenn aktiviert, wird TeslaMate MQTT als Datenquelle verwendet. Wenn deaktiviert, greift TSC direkt auf die Tesla-API zu. Ohne TeslaMate spielt diese Einstellung keine Rolle – es wird immer die Tesla-API genutzt.");
+
+    public static LocalizedText HomeGeofenceLongitude { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeGeofenceLongitude, "Home geofence longitude", "Längengrad des Heim-Geofence");
+
+    public static LocalizedText HomeGeofenceLatitude { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeGeofenceLatitude, "Home geofence latitude", "Breitengrad des Heim-Geofence");
+
+    public static LocalizedText HomeGeofenceRadius { get; } =
+        LocalizedTextFactory.CreateForProperty<BaseConfigurationBase>(b => b.HomeGeofenceRadius, "Home radius", "Heimradius");
+
+    public static LocalizedText HomeGeofenceRadiusHelper { get; } =
+        LocalizedTextFactory.Create("Increase or decrease the radius of the home geofence. Note: Values below 50m are note recommended",
+            "Passe den Radius des Heim-Geofence an. Hinweis: Werte unter 50 m werden nicht empfohlen.");
+}

--- a/TeslaSolarCharger/Shared/Localization/TextCatalog/ChargingCostTexts.cs
+++ b/TeslaSolarCharger/Shared/Localization/TextCatalog/ChargingCostTexts.cs
@@ -1,0 +1,28 @@
+using TeslaSolarCharger.Shared.Dtos.ChargingCost;
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Localization.TextCatalog;
+
+public static class ChargingCostTexts
+{
+    public static LocalizedText StartTime { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoHandledCharge>(c => c.StartTime, "Start time", "Startzeit");
+
+    public static LocalizedText EndTime { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoHandledCharge>(c => c.EndTime, "End time", "Endzeit");
+
+    public static LocalizedText CalculatedPrice { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoHandledCharge>(c => c.CalculatedPrice, "Calculated price", "Berechneter Preis");
+
+    public static LocalizedText PricePerKwh { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoHandledCharge>(c => c.PricePerKwh, "Price per kWh", "Preis pro kWh");
+
+    public static LocalizedText UsedGridEnergy { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoHandledCharge>(c => c.UsedGridEnergy, "Used grid energy", "Verbrauchte Netzenergie");
+
+    public static LocalizedText UsedHomeBatteryEnergy { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoHandledCharge>(c => c.UsedHomeBatteryEnergy, "Used home battery energy", "Verbrauchte Heimbatterie-Energie");
+
+    public static LocalizedText UsedSolarEnergy { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoHandledCharge>(c => c.UsedSolarEnergy, "Used solar energy", "Verbrauchte Solarenergie");
+}

--- a/TeslaSolarCharger/Shared/Localization/TextCatalog/ChargingScheduleTexts.cs
+++ b/TeslaSolarCharger/Shared/Localization/TextCatalog/ChargingScheduleTexts.cs
@@ -1,0 +1,28 @@
+using TeslaSolarCharger.Shared.Dtos;
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Localization.TextCatalog;
+
+public static class ChargingScheduleTexts
+{
+    public static LocalizedText ValidFrom { get; } =
+        LocalizedTextFactory.CreateForProperty<ValidFromToBase>(b => b.ValidFrom, "Valid from", "Gültig ab");
+
+    public static LocalizedText ValidTo { get; } =
+        LocalizedTextFactory.CreateForProperty<ValidFromToBase>(b => b.ValidTo, "Valid to", "Gültig bis");
+
+    public static LocalizedText CarId { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoChargingSchedule>(s => s.CarId, "Car", "Fahrzeug");
+
+    public static LocalizedText OcppChargingConnectorId { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoChargingSchedule>(s => s.OcppChargingConnectorId, "Charging connector", "Ladeanschluss");
+
+    public static LocalizedText OnlyChargeOnAtLeastSolarPower { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoChargingSchedule>(s => s.OnlyChargeOnAtLeastSolarPower, "Minimum solar power for charging", "Mindest-Solarleistung für das Laden");
+
+    public static LocalizedText ChargingPower { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoChargingSchedule>(s => s.ChargingPower, "Charging power", "Ladeleistung");
+
+    public static LocalizedText TargetGridPower { get; } =
+        LocalizedTextFactory.CreateForProperty<DtoChargingSchedule>(s => s.TargetGridPower, "Target grid power", "Ziel-Netzleistung");
+}

--- a/TeslaSolarCharger/Shared/Localization/TextCatalog/NotChargingReasonTexts.cs
+++ b/TeslaSolarCharger/Shared/Localization/TextCatalog/NotChargingReasonTexts.cs
@@ -1,0 +1,74 @@
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Localization.TextCatalog;
+
+public static class NotChargingReasonTexts
+{
+    public static LocalizedText SolarValuesTooOld { get; } =
+        LocalizedTextFactory.Create("Solar values are too old", "Die Solarwerte sind zu alt");
+
+    public static LocalizedText ChargingSpeedAdjustedDueToPowerBuffer { get; } =
+        LocalizedTextFactory.Create("Charging speed is {0} due to power buffer being set to {1}W", "Die Ladegeschwindigkeit wird {0}, weil der Leistungspuffer auf {1} W gesetzt ist");
+
+    public static LocalizedText Decreased { get; } =
+        LocalizedTextFactory.Create("decreased", "verringert");
+
+    public static LocalizedText Increased { get; } =
+        LocalizedTextFactory.Create("increased", "erhöht");
+
+    public static LocalizedText ReservedPowerForHomeBattery { get; } =
+        LocalizedTextFactory.Create("Reserved {0}W for home battery charging as its SOC ({1}%) is below minimum SOC ({2}%)", "{0} W für das Laden der Heimbatterie reserviert, da ihr SoC ({1} %) unter dem Mindest-SoC ({2} %) liegt");
+
+    public static LocalizedText CarIsFullyCharged { get; } =
+        LocalizedTextFactory.Create("Car is fully charged", "Fahrzeug ist vollständig geladen");
+
+    public static LocalizedText OcppConnectionNotEstablished { get; } =
+        LocalizedTextFactory.Create("OCPP connection not established. After a TSC or charger reboot it can take up to 5 minutes until the charger is connected again.",
+            "OCPP-Verbindung nicht hergestellt. Nach einem Neustart von TSC oder der Wallbox kann es bis zu 5 Minuten dauern, bis die Wallbox wieder verbunden ist.");
+
+    public static LocalizedText CarIsNotAtHome { get; } =
+        LocalizedTextFactory.Create("Car is not at home", "Das Fahrzeug befindet sich nicht zu Hause.");
+
+    public static LocalizedText CarIsNotPluggedIn { get; } =
+        LocalizedTextFactory.Create("Car is not plugged in", "Das Fahrzeug ist nicht eingesteckt.");
+
+    public static LocalizedText ChargingConnectorIsNotPluggedIn { get; } =
+        LocalizedTextFactory.Create("Charging connector is not plugged in", "Der Ladeanschluss ist nicht eingesteckt.");
+
+    public static LocalizedText MaxCombinedCurrentTooLow { get; } =
+        LocalizedTextFactory.Create("Charging stopped because of not enough max combined current.", "Ladevorgang gestoppt, da der maximale Gesamtstrom nicht ausreicht.");
+
+    public static LocalizedText ChargeModeOffOrMaxSocReached { get; } =
+        LocalizedTextFactory.Create("Charge mode is off or max SoC is reached.", "Der Lademodus ist deaktiviert oder das maximale SoC wurde erreicht.");
+
+    public static LocalizedText MinOrMaxPhasesUnknown { get; } =
+        LocalizedTextFactory.Create("Min Phases or Max Phases is unkown. Check the logs for further details.", "Die minimalen oder maximalen Phasen sind unbekannt. Bitte prüfe die Protokolle für weitere Details.");
+
+    public static LocalizedText EstimatedVoltageUnknown { get; } =
+        LocalizedTextFactory.Create("Estimated voltage while charging is unkown. Check the logs for further details.", "Die geschätzte Spannung während des Ladens ist unbekannt. Bitte prüfe die Protokolle für weitere Details.");
+
+    public static LocalizedText WaitingForPhaseSwitchCooldown { get; } =
+        LocalizedTextFactory.Create("Waiting phase switch cooldown time before starting to charge", "Warte auf die Abkühlzeit für den Phasenwechsel, bevor geladen wird.");
+
+    public static LocalizedText WaitingForPhaseReduction { get; } =
+        LocalizedTextFactory.Create("Waiting for phase reduction", "Warte auf Phasenreduzierung.");
+
+    public static LocalizedText WaitingForPhaseIncrease { get; } =
+        LocalizedTextFactory.Create("Waiting for phase increase", "Warte auf Phasenerhöhung.");
+
+    public static LocalizedText WaitingForChargeStop { get; } =
+        LocalizedTextFactory.Create("Waiting for charge stop", "Warte auf das Ende des Ladevorgangs.");
+
+    public static LocalizedText ConfiguredMaxSocReached { get; } =
+        LocalizedTextFactory.Create("Configured max Soc is reached", "Das konfigurierte maximale SoC wurde erreicht.");
+
+    public static LocalizedText CarSocLimitReached { get; } =
+        LocalizedTextFactory.Create("Car side SOC limit is reached. To start charging, the car side SOC limit needs to be at least {0}% higher than the actual SOC.",
+            "Das fahrzeugseitige SoC-Limit wurde erreicht. Zum Starten des Ladevorgangs muss das fahrzeugseitige Limit mindestens {0}% über dem aktuellen SoC liegen.");
+
+    public static LocalizedText ChargingStoppedByCar { get; } =
+        LocalizedTextFactory.Create("Charging stopped by car, e.g. it is full or its charge limit is reached.", "Das Fahrzeug hat den Ladevorgang beendet, z. B. weil es voll ist oder das Limit erreicht wurde.");
+
+    public static LocalizedText WaitingForChargeStart { get; } =
+        LocalizedTextFactory.Create("Waiting for charge start", "Warte auf den Ladebeginn.");
+}

--- a/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using TeslaSolarCharger.Shared.Helper;
 using TeslaSolarCharger.Shared.Helper.Contracts;
+using TeslaSolarCharger.Shared.Localization;
 using TeslaSolarCharger.Shared.Resources;
 using TeslaSolarCharger.Shared.Resources.Contracts;
 
@@ -11,6 +12,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddSharedDependencies(this IServiceCollection services) =>
         services
             .AddTransient<IStringHelper, StringHelper>()
+            .AddTransient<ITextLocalizer, CurrentCultureTextLocalizer>()
             .AddTransient<IConstants, Constants>()
             .AddTransient<IValidFromToHelper, ValidFromToHelper>()
         ;


### PR DESCRIPTION
## Summary
- add strongly typed localization infrastructure for shared texts and register a culture-aware text localizer
- replace inline configuration display/helper strings with localized catalogs and attributes
- localize server-generated "not charging" reasons so client text is provided per language

## Testing
- dotnet build TeslaSolarCharger.sln

------
https://chatgpt.com/codex/tasks/task_e_68ebefde11dc8324b99ac0e23e98fbb4