### PR TITLE
Add localization support to navigation menu

### DIFF
--- a/TeslaSolarCharger/Client/Shared/NavMenu.razor
+++ b/TeslaSolarCharger/Client/Shared/NavMenu.razor
@@ -1,9 +1,15 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+@using TeslaSolarCharger.Shared.Localization.Contracts
+@using TeslaSolarCharger.Shared.Localization.Registries
+@using TeslaSolarCharger.Shared.Localization.Registries.Components
+
+@inject ITextLocalizationService TextLocalizer
+
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href=""><span class="material-symbols-outlined">
             solar_power
-        </span> Tesla Solar Charger</a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
+        </span> @T("Tesla Solar Charger")</a>
+        <button title='@T("Navigation menu")' class="navbar-toggler" @onclick="ToggleNavMenu">
             <span class="navbar-toggler-icon"></span>
         </button>
     </div>
@@ -13,42 +19,42 @@
     <nav class="flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link px-3" href="" Match="NavLinkMatch.All">
-                <span class="oi oi-home" aria-hidden="true"></span> Overview
+                <span class="oi oi-home" aria-hidden="true"></span> @T("Overview")
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link px-3" href="ChargingStations">
-                <span class="material-symbols-outlined pr-1" aria-hidden="true">ev_station</span> Charging Stations
+                <span class="material-symbols-outlined pr-1" aria-hidden="true">ev_station</span> @T("Charging Stations")
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link px-3" href="CarSettings">
-                <span class="oi oi-wrench" aria-hidden="true"></span> Car Settings
+                <span class="oi oi-wrench" aria-hidden="true"></span> @T("Car Settings")
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link px-3" href="ChargePrices">
-                <span class="material-symbols-outlined" aria-hidden="true">attach_money</span> Charge Prices
+                <span class="material-symbols-outlined" aria-hidden="true">attach_money</span> @T("Charge Prices")
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link px-3" href="cloudconnection">
-                <span class="oi oi-cloud" aria-hidden="true"></span> Cloud Connection
+                <span class="oi oi-cloud" aria-hidden="true"></span> @T("Cloud Connection")
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link px-3" href="BaseConfiguration">
-                <span class="oi oi-cog" aria-hidden="true"></span> Base Configuration
+                <span class="oi oi-cog" aria-hidden="true"></span> @T("Base Configuration")
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link px-3" href="support">
-                <span class="oi oi-code" aria-hidden="true"></span> Support
+                <span class="oi oi-code" aria-hidden="true"></span> @T("Support")
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link px-3" href="backupAndRestore">
-                <span class="oi oi-data-transfer-download" aria-hidden="true"></span> Backup and Restore
+                <span class="oi oi-data-transfer-download" aria-hidden="true"></span> @T("Backup and Restore")
             </NavLink>
         </div>
     </nav>
@@ -58,6 +64,10 @@
     private bool _collapseNavMenu = true;
 
     private string? NavMenuCssClass => _collapseNavMenu ? "collapse" : null;
+
+    private string T(string key) =>
+        TextLocalizer.Get<NavMenuComponentLocalizationRegistry>(key, typeof(SharedComponentLocalizationRegistry))
+        ?? key;
 
     private void ToggleNavMenu()
     {

--- a/TeslaSolarCharger/Shared/Localization/Registries/Components/NavMenuComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Components/NavMenuComponentLocalizationRegistry.cs
@@ -1,0 +1,49 @@
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Localization.Registries.Components;
+
+public class NavMenuComponentLocalizationRegistry : TextLocalizationRegistry<NavMenuComponentLocalizationRegistry>
+{
+    protected override void Configure()
+    {
+        Register("Tesla Solar Charger",
+            new TextLocalizationTranslation(LanguageCodes.English, "Tesla Solar Charger"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Tesla Solar Charger"));
+
+        Register("Navigation menu",
+            new TextLocalizationTranslation(LanguageCodes.English, "Navigation menu"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Navigationsmenü"));
+
+        Register("Overview",
+            new TextLocalizationTranslation(LanguageCodes.English, "Overview"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Übersicht"));
+
+        Register("Charging Stations",
+            new TextLocalizationTranslation(LanguageCodes.English, "Charging Stations"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Ladestationen"));
+
+        Register("Car Settings",
+            new TextLocalizationTranslation(LanguageCodes.English, "Car Settings"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeugeinstellungen"));
+
+        Register("Charge Prices",
+            new TextLocalizationTranslation(LanguageCodes.English, "Charge Prices"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Ladepreise"));
+
+        Register("Cloud Connection",
+            new TextLocalizationTranslation(LanguageCodes.English, "Cloud Connection"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Cloud-Verbindung"));
+
+        Register("Base Configuration",
+            new TextLocalizationTranslation(LanguageCodes.English, "Base Configuration"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Basiskonfiguration"));
+
+        Register("Support",
+            new TextLocalizationTranslation(LanguageCodes.English, "Support"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Support"));
+
+        Register("Backup and Restore",
+            new TextLocalizationTranslation(LanguageCodes.English, "Backup and Restore"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Backup und Wiederherstellung"));
+    }
+}

--- a/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ITextLocalizationRegistry, AutoReloadOnVersionChangeComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, BackupComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, ChargingStationConnectorsComponentLocalizationRegistry>()
+            .AddSingleton<ITextLocalizationRegistry, NavMenuComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, CustomIconLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, CarDetailsComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, GenericValueConfigurationComponentLocalizationRegistry>()


### PR DESCRIPTION
## Summary
- add a text localization registry dedicated to the navigation menu
- update the nav menu component to use the localization service for all labels
- register the new registry with the shared service collection

## Testing
- dotnet build TeslaSolarCharger.sln

------
https://chatgpt.com/codex/tasks/task_e_68ed4911f7e483248991592c0e26064c