### PR TITLE
Localize not charging reasons on the server

### DIFF
--- a/TeslaSolarCharger/Server/Helper/NotChargingWithExpectedPowerReasonHelper.cs
+++ b/TeslaSolarCharger/Server/Helper/NotChargingWithExpectedPowerReasonHelper.cs
@@ -1,8 +1,11 @@
-﻿using TeslaSolarCharger.Server.Helper.Contracts;
+using System.Globalization;
+using TeslaSolarCharger.Server.Helper.Contracts;
 using TeslaSolarCharger.Server.SignalR.Notifiers.Contracts;
 using TeslaSolarCharger.Shared.Contracts;
 using TeslaSolarCharger.Shared.Dtos.Contracts;
 using TeslaSolarCharger.Shared.Dtos.Home;
+using TeslaSolarCharger.Shared.Localization.Contracts;
+using TeslaSolarCharger.Shared.Localization.Registries.Reasons;
 using TeslaSolarCharger.Shared.SignalRClients;
 
 namespace TeslaSolarCharger.Server.Helper;
@@ -13,29 +16,35 @@ public class NotChargingWithExpectedPowerReasonHelper : INotChargingWithExpected
     private readonly ISettings _settings;
     private readonly IAppStateNotifier _appStateNotifier;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly ITextLocalizationService _textLocalizationService;
+
+    private readonly List<DtoNotChargingWithExpectedPowerReason> _genericReasons = new();
+    private readonly Dictionary<(int? carId, int? connectorId), List<DtoNotChargingWithExpectedPowerReason>> _loadPointSpecificReasons = new();
 
     public NotChargingWithExpectedPowerReasonHelper(ILogger<NotChargingWithExpectedPowerReasonHelper> logger,
         ISettings settings,
         IAppStateNotifier appStateNotifier,
-        IDateTimeProvider dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        ITextLocalizationService textLocalizationService)
     {
         _logger = logger;
         _settings = settings;
         _appStateNotifier = appStateNotifier;
         _dateTimeProvider = dateTimeProvider;
+        _textLocalizationService = textLocalizationService;
     }
-    private readonly List<DtoNotChargingWithExpectedPowerReason> _genericReasons = new();
-    private readonly Dictionary<(int? carId, int? connectorId), List<DtoNotChargingWithExpectedPowerReason>> _loadPointSpecificReasons = new();
 
     public void AddGenericReason(DtoNotChargingWithExpectedPowerReason reason)
     {
-        _logger.LogTrace("{method}({reason})", nameof(AddGenericReason), reason.Reason);
+        var reasonDescription = reason.Reason ?? reason.LocalizationKey ?? string.Empty;
+        _logger.LogTrace("{method}({reason})", nameof(AddGenericReason), reasonDescription);
         _genericReasons.Add(reason);
     }
 
     public void AddLoadPointSpecificReason(int? carId, int? connectorId, DtoNotChargingWithExpectedPowerReason reason)
     {
-        _logger.LogTrace("{method}({carId}, {connectorId}, {reason})", nameof(AddLoadPointSpecificReason), carId, connectorId, reason.Reason);
+        var reasonDescription = reason.Reason ?? reason.LocalizationKey ?? string.Empty;
+        _logger.LogTrace("{method}({carId}, {connectorId}, {reason})", nameof(AddLoadPointSpecificReason), carId, connectorId, reasonDescription);
         var key = (carId, connectorId);
         if (!_loadPointSpecificReasons.ContainsKey(key))
         {
@@ -76,6 +85,39 @@ public class NotChargingWithExpectedPowerReasonHelper : INotChargingWithExpected
             }
         }
 
-        return allReasons;
+        return allReasons
+            .Select(LocalizeReason)
+            .ToList();
+    }
+
+    private DtoNotChargingWithExpectedPowerReason LocalizeReason(DtoNotChargingWithExpectedPowerReason reason)
+    {
+        if (reason == default)
+        {
+            return new(string.Empty);
+        }
+
+        var culture = CultureInfo.CurrentUICulture;
+
+        if (!string.IsNullOrWhiteSpace(reason.LocalizationKey))
+        {
+            var translation = _textLocalizationService
+                .Get<NotChargingWithExpectedPowerReasonLocalizationRegistry>(reason.LocalizationKey!, culture)
+                ?? reason.LocalizationKey!;
+
+            var arguments = reason.LocalizationArguments?.ToArray();
+            var localizedReason = (arguments != default && arguments.Length > 0)
+                ? string.Format(culture, translation, arguments)
+                : translation;
+
+            return reason.CloneWithReason(localizedReason);
+        }
+
+        if (!string.IsNullOrWhiteSpace(reason.Reason))
+        {
+            return reason.CloneWithReason(reason.Reason);
+        }
+
+        return reason.CloneWithReason(string.Empty);
     }
 }

--- a/TeslaSolarCharger/Server/Services/TargetChargingValueCalculationService.cs
+++ b/TeslaSolarCharger/Server/Services/TargetChargingValueCalculationService.cs
@@ -10,6 +10,7 @@ using TeslaSolarCharger.Shared.Dtos.Home;
 using TeslaSolarCharger.Shared.Dtos.Settings;
 using TeslaSolarCharger.Shared.Enums;
 using TeslaSolarCharger.Shared.Resources.Contracts;
+using TeslaSolarCharger.Shared.Localization.Registries.Reasons;
 
 namespace TeslaSolarCharger.Server.Services;
 
@@ -85,7 +86,10 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 cancellationToken).ConfigureAwait(false);
             if (constraintValues.IsCarFullyCharged == true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId, new DtoNotChargingWithExpectedPowerReason("Car is fully charged"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(
+                    loadPoint.LoadPoint.CarId,
+                    loadPoint.LoadPoint.ChargingConnectorId,
+                    DtoNotChargingWithExpectedPowerReason.Create(NotChargingWithExpectedPowerReasonLocalizationKeys.CarFullyCharged));
             }
             var powerToControlIncludingHomeBatteryDischargePower = powerToControl + additionalHomeBatteryDischargePower;
             var chargingSchedulePower = chargingSchedule.TargetGridPower.HasValue && (chargingSchedule.ChargingPower < (powerToControl + (chargingSchedule.TargetGridPower ?? 0)))
@@ -114,7 +118,10 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 cancellationToken).ConfigureAwait(false);
             if (constraintValues.IsCarFullyCharged == true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId, new DtoNotChargingWithExpectedPowerReason("Car is fully charged"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(
+                    loadPoint.LoadPoint.CarId,
+                    loadPoint.LoadPoint.ChargingConnectorId,
+                    DtoNotChargingWithExpectedPowerReason.Create(NotChargingWithExpectedPowerReasonLocalizationKeys.CarFullyCharged));
             }
 
             var powerToControlIncludingHomeBatteryDischargePower = powerToControl;

--- a/TeslaSolarCharger/Shared/Dtos/Home/DtoNotChargingWithExpectedPowerReason.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Home/DtoNotChargingWithExpectedPowerReason.cs
@@ -1,4 +1,8 @@
-﻿namespace TeslaSolarCharger.Shared.Dtos.Home;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace TeslaSolarCharger.Shared.Dtos.Home;
 
 public class DtoNotChargingWithExpectedPowerReason
 {
@@ -7,8 +11,9 @@ public class DtoNotChargingWithExpectedPowerReason
     public DtoNotChargingWithExpectedPowerReason()
 #pragma warning restore CS8618, CS9264
     {
-        
+
     }
+
     public DtoNotChargingWithExpectedPowerReason(string reason)
     {
         Reason = reason;
@@ -20,5 +25,33 @@ public class DtoNotChargingWithExpectedPowerReason
     }
 
     public string Reason { get; set; }
+
     public DateTimeOffset? ReasonEndTime { get; set; }
+
+    [JsonIgnore]
+    public string? LocalizationKey { get; set; }
+
+    [JsonIgnore]
+    public List<object?>? LocalizationArguments { get; set; }
+
+    public static DtoNotChargingWithExpectedPowerReason Create(string localizationKey,
+        DateTimeOffset? reasonEndTime = null,
+        params object?[] localizationArguments)
+    {
+        return new()
+        {
+            LocalizationKey = localizationKey,
+            ReasonEndTime = reasonEndTime,
+            LocalizationArguments = localizationArguments?.ToList()
+        };
+    }
+
+    public DtoNotChargingWithExpectedPowerReason CloneWithReason(string reason)
+    {
+        return new(reason, ReasonEndTime)
+        {
+            LocalizationKey = LocalizationKey,
+            LocalizationArguments = LocalizationArguments?.ToList()
+        };
+    }
 }

--- a/TeslaSolarCharger/Shared/Localization/Registries/Reasons/NotChargingWithExpectedPowerReasonLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Reasons/NotChargingWithExpectedPowerReasonLocalizationRegistry.cs
@@ -1,0 +1,38 @@
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Localization.Registries.Reasons;
+
+public static class NotChargingWithExpectedPowerReasonLocalizationKeys
+{
+    public const string SolarValuesTooOld = nameof(SolarValuesTooOld);
+    public const string ChargingSpeedDecreasedDueToPowerBuffer = nameof(ChargingSpeedDecreasedDueToPowerBuffer);
+    public const string ChargingSpeedIncreasedDueToPowerBuffer = nameof(ChargingSpeedIncreasedDueToPowerBuffer);
+    public const string ReservedPowerForHomeBatteryDueToLowSoc = nameof(ReservedPowerForHomeBatteryDueToLowSoc);
+    public const string CarFullyCharged = nameof(CarFullyCharged);
+}
+
+public class NotChargingWithExpectedPowerReasonLocalizationRegistry : TextLocalizationRegistry<NotChargingWithExpectedPowerReasonLocalizationRegistry>
+{
+    protected override void Configure()
+    {
+        Register(NotChargingWithExpectedPowerReasonLocalizationKeys.SolarValuesTooOld,
+            new TextLocalizationTranslation(LanguageCodes.English, "Solar values are too old"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Solardaten sind zu alt"));
+
+        Register(NotChargingWithExpectedPowerReasonLocalizationKeys.ChargingSpeedDecreasedDueToPowerBuffer,
+            new TextLocalizationTranslation(LanguageCodes.English, "Charging speed is decreased due to power buffer being set to {0}W"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Die Ladegeschwindigkeit ist reduziert, da der Leistungspuffer auf {0} W gesetzt ist"));
+
+        Register(NotChargingWithExpectedPowerReasonLocalizationKeys.ChargingSpeedIncreasedDueToPowerBuffer,
+            new TextLocalizationTranslation(LanguageCodes.English, "Charging speed is increased due to power buffer being set to {0}W"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Die Ladegeschwindigkeit ist erhöht, da der Leistungspuffer auf {0} W gesetzt ist"));
+
+        Register(NotChargingWithExpectedPowerReasonLocalizationKeys.ReservedPowerForHomeBatteryDueToLowSoc,
+            new TextLocalizationTranslation(LanguageCodes.English, "Reserved {0}W for home battery charging as its state of charge ({1}%) is below the minimum ({2}%)"),
+            new TextLocalizationTranslation(LanguageCodes.German, "{0} W für das Laden der Hausbatterie reserviert, da ihr Ladezustand ({1} %) unter dem Minimum ({2} %) liegt"));
+
+        Register(NotChargingWithExpectedPowerReasonLocalizationKeys.CarFullyCharged,
+            new TextLocalizationTranslation(LanguageCodes.English, "Car is fully charged"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Das Auto ist vollständig geladen"));
+    }
+}

--- a/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using TeslaSolarCharger.Shared.Localization.Registries;
 using TeslaSolarCharger.Shared.Localization.Registries.Components;
 using TeslaSolarCharger.Shared.Localization.Registries.Components.StartPage;
 using TeslaSolarCharger.Shared.Localization.Registries.Pages;
+using TeslaSolarCharger.Shared.Localization.Registries.Reasons;
 using TeslaSolarCharger.Shared.Resources;
 using TeslaSolarCharger.Shared.Resources.Contracts;
 
@@ -59,6 +60,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ITextLocalizationRegistry, LoggedErrorsComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, ManualOcppChargingComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, NotChargingAtExpectedPowerReasonsComponentLocalizationRegistry>()
+            .AddSingleton<ITextLocalizationRegistry, NotChargingWithExpectedPowerReasonLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, PowerBufferComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, InstallationInformationLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, MerryChristmasAndHappyNewYearComponentLocalizationRegistry>()


### PR DESCRIPTION
## Summary
- extend not-charging reason DTOs to carry localization metadata so backend strings can be formatted per culture
- add a localization registry and use the shared text localization service in the helper and charging services to emit localized reasons
- register the new registry with dependency injection to expose translations to the server

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68ed576028008324ac8f7886a12d5337