### PR TITLE
Localize backend not charging reason messages

### DIFF
--- a/TeslaSolarCharger/Server/Helper/Contracts/INotChargingWithExpectedPowerReasonHelper.cs
+++ b/TeslaSolarCharger/Server/Helper/Contracts/INotChargingWithExpectedPowerReasonHelper.cs
@@ -4,8 +4,8 @@ namespace TeslaSolarCharger.Server.Helper.Contracts;
 
 public interface INotChargingWithExpectedPowerReasonHelper
 {
-    void AddGenericReason(DtoNotChargingWithExpectedPowerReason reason);
-    void AddLoadPointSpecificReason(int? carId, int? connectorId, DtoNotChargingWithExpectedPowerReason reason);
+    void AddGenericReason(NotChargingWithExpectedPowerReasonTemplate reason);
+    void AddLoadPointSpecificReason(int? carId, int? connectorId, NotChargingWithExpectedPowerReasonTemplate reason);
 
     Task UpdateReasonsInSettings();
 

--- a/TeslaSolarCharger/Server/Services/ChargingServiceV2.cs
+++ b/TeslaSolarCharger/Server/Services/ChargingServiceV2.cs
@@ -325,7 +325,8 @@ public class ChargingServiceV2 : IChargingServiceV2
         {
             if (!_settings.OcppConnectorStates.ContainsKey(connectorId))
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(null, connectorId, new("OCPP connection not established. After a TSC or charger reboot it can take up to 5 minutes until the charger is connected again."));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(null, connectorId,
+                    new NotChargingWithExpectedPowerReasonTemplate("OCPP connection not established. After a TSC or charger reboot it can take up to 5 minutes until the charger is connected again."));
             }
         }
     }
@@ -336,12 +337,14 @@ public class ChargingServiceV2 : IChargingServiceV2
         {
             if (dtoCar.IsHomeGeofence.Value != true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(dtoCar.Id, null, new("Car is not at home"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(dtoCar.Id, null,
+                    new NotChargingWithExpectedPowerReasonTemplate("Car is not at home"));
             }
 
             if (dtoCar.PluggedIn.Value != true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(dtoCar.Id, null, new("Car is not plugged in"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(dtoCar.Id, null,
+                    new NotChargingWithExpectedPowerReasonTemplate("Car is not plugged in"));
             }
         }
 
@@ -349,7 +352,8 @@ public class ChargingServiceV2 : IChargingServiceV2
         {
             if (!settingsOcppConnectorState.Value.IsPluggedIn.Value)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(null, settingsOcppConnectorState.Key, new("Charging connector is not plugged in"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(null, settingsOcppConnectorState.Key,
+                    new NotChargingWithExpectedPowerReasonTemplate("Charging connector is not plugged in"));
             }
         }
     }

--- a/TeslaSolarCharger/Server/Services/PowerToControlCalculationService.cs
+++ b/TeslaSolarCharger/Server/Services/PowerToControlCalculationService.cs
@@ -196,7 +196,11 @@ public class PowerToControlCalculationService : IPowerToControlCalculationServic
         var homeBatteryMaxChargingPower = _configurationWrapper.HomeBatteryChargingPower();
         if (actualHomeBatterySoc < homeBatteryMinSoc)
         {
-            notChargingWithExpectedPowerReasonHelper.AddGenericReason(new($"Reserved {homeBatteryMaxChargingPower}W for Home battery charging as its SOC ({actualHomeBatterySoc}%) is below minimum SOC ({homeBatteryMinSoc}%)"));
+            notChargingWithExpectedPowerReasonHelper.AddGenericReason(
+                new NotChargingWithExpectedPowerReasonTemplate("Reserved {0}W for Home battery charging as its SOC ({1}%) is below minimum SOC ({2}%)",
+                    homeBatteryMaxChargingPower ?? 0,
+                    actualHomeBatterySoc,
+                    homeBatteryMinSoc));
             return homeBatteryMaxChargingPower ?? 0;
         }
 

--- a/TeslaSolarCharger/Server/Services/TargetChargingValueCalculationService.cs
+++ b/TeslaSolarCharger/Server/Services/TargetChargingValueCalculationService.cs
@@ -85,7 +85,8 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 cancellationToken).ConfigureAwait(false);
             if (constraintValues.IsCarFullyCharged == true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId, new DtoNotChargingWithExpectedPowerReason("Car is fully charged"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId,
+                    new NotChargingWithExpectedPowerReasonTemplate("Car is fully charged"));
             }
             var powerToControlIncludingHomeBatteryDischargePower = powerToControl + additionalHomeBatteryDischargePower;
             var chargingSchedulePower = chargingSchedule.TargetGridPower.HasValue && (chargingSchedule.ChargingPower < (powerToControl + (chargingSchedule.TargetGridPower ?? 0)))
@@ -114,7 +115,8 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 cancellationToken).ConfigureAwait(false);
             if (constraintValues.IsCarFullyCharged == true)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId, new DtoNotChargingWithExpectedPowerReason("Car is fully charged"));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadPoint.LoadPoint.CarId, loadPoint.LoadPoint.ChargingConnectorId,
+                    new NotChargingWithExpectedPowerReasonTemplate("Car is fully charged"));
             }
 
             var powerToControlIncludingHomeBatteryDischargePower = powerToControl;
@@ -229,7 +231,8 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
         if (constraintValues.MaxCurrent < constraintValues.MinCurrent)
         {
             _logger.LogWarning("Max current {maxCurrent} is lower than min current {minCurrent} for loadpoint {@loadpoint}. Very likely due to low configured \"Max combined charging current\" in Base Configuration.", constraintValues.MaxCurrent, constraintValues.MinCurrent, loadpoint);
-            _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId, new("Charging stopped because of not enough max combined current."));
+            _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
+                new NotChargingWithExpectedPowerReasonTemplate("Charging stopped because of not enough max combined current."));
             return constraintValues.IsCharging == true ? new TargetValues() { StopCharging = true, } : null;
         }
         if (constraintValues.ChargeMode == ChargeModeV2.Manual)
@@ -240,7 +243,8 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
         if ((constraintValues.ChargeMode == ChargeModeV2.Off)
             || (constraintValues.Soc > constraintValues.MaxSoc && !ignoreTimers))
         {
-            _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId, new("Charge mode is off or max SoC is reached."));
+            _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
+                new NotChargingWithExpectedPowerReasonTemplate("Charge mode is off or max SoC is reached."));
             return constraintValues.IsCharging == true ? new TargetValues() { StopCharging = true, } : null;
         }
         if (constraintValues.IsCarFullyCharged == true)
@@ -267,13 +271,15 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 : null;
             if (constraintValues.MinPhases == default || constraintValues.MaxPhases == default)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId, new("Min Phases or Max Phases is unkown. Check the logs for further details."));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
+                    new NotChargingWithExpectedPowerReasonTemplate("Min Phases or Max Phases is unkown. Check the logs for further details."));
                 _logger.LogWarning("Can not handle loadpoint {@loadpoint} as minphases or maxphases is not known", loadpoint);
                 return null;
             }
             if (loadpoint.EstimatedVoltageWhileCharging == default)
             {
-                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId, new("Estimated voltage while charging is unkown. Check the logs for further details."));
+                _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
+                    new NotChargingWithExpectedPowerReasonTemplate("Estimated voltage while charging is unkown. Check the logs for further details."));
                 _logger.LogWarning("Can not handle loadpoint {@loadpoint} as estimated voltage while charging is not known", loadpoint);
                 return null;
             }
@@ -291,7 +297,10 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 {
                     _logger.LogTrace("Stopping charging to allow phase reduction for loadpoint {@loadpoint}", loadpoint);
                     _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                        new("Waiting phase switch cooldown time before starting to charge", currentDate + constraintValues.PhaseSwitchCoolDownTime + _configurationWrapper.ChargingValueJobUpdateIntervall()));
+                        new NotChargingWithExpectedPowerReasonTemplate("Waiting phase switch cooldown time before starting to charge")
+                        {
+                            ReasonEndTime = currentDate + constraintValues.PhaseSwitchCoolDownTime + _configurationWrapper.ChargingValueJobUpdateIntervall(),
+                        });
                     return new() { StopCharging = true, };
                 }
                 phasesToUse = 1;
@@ -306,7 +315,10 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
             {
                 _logger.LogTrace("Loadpoint {@loadpoint} is not charging with expected power as it should reduce phases but is not allowed to do so.", loadpoint);
                 _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                    new("Waiting for phase reduction", constraintValues.PhaseReductionAllowedAt + _configurationWrapper.ChargingValueJobUpdateIntervall()));
+                    new NotChargingWithExpectedPowerReasonTemplate("Waiting for phase reduction")
+                    {
+                        ReasonEndTime = constraintValues.PhaseReductionAllowedAt + _configurationWrapper.ChargingValueJobUpdateIntervall(),
+                    });
             }
             // should increase phases and is allowed
             else if ((currentToSet > constraintValues.MaxCurrent)
@@ -319,7 +331,10 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 {
                     _logger.LogTrace("Stopping charging to allow phase increase for loadpoint {@loadpoint}", loadpoint);
                     _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                        new("Waiting phase switch cooldown time before starting to charge", currentDate + constraintValues.PhaseSwitchCoolDownTime + _configurationWrapper.ChargingValueJobUpdateIntervall()));
+                        new NotChargingWithExpectedPowerReasonTemplate("Waiting phase switch cooldown time before starting to charge")
+                        {
+                            ReasonEndTime = currentDate + constraintValues.PhaseSwitchCoolDownTime + _configurationWrapper.ChargingValueJobUpdateIntervall(),
+                        });
                     return new() { StopCharging = true, };
                 }
                 phasesToUse = 3;
@@ -332,7 +347,10 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
             {
                 _logger.LogTrace("Loadpoint {@loadpoint} is not charging with expected power as it should increase phases but is not allowed to do so.", loadpoint);
                 _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                    new("Waiting for phase increase", constraintValues.PhaseIncreaseAllowedAt + _configurationWrapper.ChargingValueJobUpdateIntervall()));
+                    new NotChargingWithExpectedPowerReasonTemplate("Waiting for phase increase")
+                    {
+                        ReasonEndTime = constraintValues.PhaseIncreaseAllowedAt + _configurationWrapper.ChargingValueJobUpdateIntervall(),
+                    });
             }
             //recalculate current to set based on phases to use
             currentToSet = powerToSet * (1m / (loadpoint.EstimatedVoltageWhileCharging.Value * phasesToUse));
@@ -352,7 +370,10 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 && (constraintValues.IsCharging == true))
             {
                 _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                    new("Waiting for charge stop", constraintValues.ChargeStopAllowedAt + _configurationWrapper.ChargingValueJobUpdateIntervall()));
+                    new NotChargingWithExpectedPowerReasonTemplate("Waiting for charge stop")
+                    {
+                        ReasonEndTime = constraintValues.ChargeStopAllowedAt + _configurationWrapper.ChargingValueJobUpdateIntervall(),
+                    });
             }
 
             if (constraintValues.IsCharging != true)
@@ -361,19 +382,20 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                 if (constraintValues.Soc >= constraintValues.MaxSoc && !ignoreTimers)
                 {
                     _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                        new("Configured max Soc is reached"));
+                        new NotChargingWithExpectedPowerReasonTemplate("Configured max Soc is reached"));
                     return null;
                 }
                 if (constraintValues.CarSocLimit <= (constraintValues.Soc + _constants.MinimumSocDifference))
                 {
                     _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                        new($"Car side SOC limit is reached. To start charging, the car side SOC limit needs to be at least {_constants.MinimumSocDifference}% higher than the actual SOC."));
+                        new NotChargingWithExpectedPowerReasonTemplate("Car side SOC limit is reached. To start charging, the car side SOC limit needs to be at least {0}% higher than the actual SOC.", _constants.MinimumSocDifference));
                     return null;
                 }
                 if (constraintValues.IsCarFullyCharged == true
                     && !loadpoint.ManageChargingPowerByCar)
                 {
-                    _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId, new("Charging stopped by car, e.g. it is full or its charge limit is reached."));
+                    _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
+                        new NotChargingWithExpectedPowerReasonTemplate("Charging stopped by car, e.g. it is full or its charge limit is reached."));
                     return null;
                 }
                 if ((constraintValues.ChargeStartAllowed != true) && (!ignoreTimers))
@@ -381,7 +403,10 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                     if (constraintValues.ChargeStartAllowedAt != default)
                     {
                         _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                            new("Waiting for charge start", constraintValues.ChargeStartAllowedAt + _configurationWrapper.ChargingValueJobUpdateIntervall()));
+                            new NotChargingWithExpectedPowerReasonTemplate("Waiting for charge start")
+                            {
+                                ReasonEndTime = constraintValues.ChargeStartAllowedAt + _configurationWrapper.ChargingValueJobUpdateIntervall(),
+                            });
                     }
                     return null;
                 }
@@ -389,8 +414,11 @@ public class TargetChargingValueCalculationService : ITargetChargingValueCalcula
                     && (constraintValues.LastIsChargingChange > (currentDate - constraintValues.PhaseSwitchCoolDownTime)))
                 {
                     _logger.LogTrace("Waitingcool down time of {coolDownTime} before starting to charge", loadpoint);
-                    _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
-                        new("Waiting phase switch cooldown time before starting to charge", constraintValues.LastIsChargingChange + constraintValues.PhaseSwitchCoolDownTime + _configurationWrapper.ChargingValueJobUpdateIntervall()));
+                        _notChargingWithExpectedPowerReasonHelper.AddLoadPointSpecificReason(loadpoint.CarId, loadpoint.ChargingConnectorId,
+                            new NotChargingWithExpectedPowerReasonTemplate("Waiting phase switch cooldown time before starting to charge")
+                            {
+                                ReasonEndTime = constraintValues.LastIsChargingChange + constraintValues.PhaseSwitchCoolDownTime + _configurationWrapper.ChargingValueJobUpdateIntervall(),
+                            });
                     return null;
                 }
 

--- a/TeslaSolarCharger/Shared/Dtos/Contracts/ISettings.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Contracts/ISettings.cs
@@ -33,8 +33,8 @@ public interface ISettings
     ConcurrentDictionary<int, DtoOcppConnectorState> OcppConnectorStates { get; set; }
 
     ConcurrentBag<DtoChargingSchedule> ChargingSchedules { get; set; }
-    ConcurrentBag<DtoNotChargingWithExpectedPowerReason> GenericNotChargingWithExpectedPowerReasons { get; set; }
-    ConcurrentDictionary<(int? carId, int? connectorId), List<DtoNotChargingWithExpectedPowerReason>> LoadPointSpecificNotChargingWithExpectedPowerReasons { get; set; }
+    ConcurrentBag<NotChargingWithExpectedPowerReasonTemplate> GenericNotChargingWithExpectedPowerReasons { get; set; }
+    ConcurrentDictionary<(int? carId, int? connectorId), List<NotChargingWithExpectedPowerReasonTemplate>> LoadPointSpecificNotChargingWithExpectedPowerReasons { get; set; }
     ConcurrentDictionary<int, (int? carId, DateTimeOffset combinationTimeStamp)> ManualSetLoadPointCarCombinations { get; set; }
     HashSet<DtoLoadpointCombination> LatestLoadPointCombinations { get; set; }
     int? LastLoggedHomeBatterySoc { get; set; }

--- a/TeslaSolarCharger/Shared/Dtos/Home/NotChargingWithExpectedPowerReasonTemplate.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Home/NotChargingWithExpectedPowerReasonTemplate.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Globalization;
+using TeslaSolarCharger.Shared.Localization.Contracts;
+using TeslaSolarCharger.Shared.Localization.Registries;
+using TeslaSolarCharger.Shared.Localization.Registries.Server;
+
+namespace TeslaSolarCharger.Shared.Dtos.Home;
+
+public class NotChargingWithExpectedPowerReasonTemplate
+{
+    public NotChargingWithExpectedPowerReasonTemplate()
+    {
+    }
+
+    public NotChargingWithExpectedPowerReasonTemplate(string localizationKey, params object?[] formatArguments)
+    {
+        LocalizationKey = localizationKey ?? throw new ArgumentNullException(nameof(localizationKey));
+        if (formatArguments?.Length > 0)
+        {
+            FormatArguments = formatArguments;
+        }
+    }
+
+    public string LocalizationKey { get; set; } = string.Empty;
+
+    public object?[]? FormatArguments { get; set; }
+
+    public DateTimeOffset? ReasonEndTime { get; set; }
+
+    public NotChargingWithExpectedPowerReasonTemplate Clone()
+    {
+        return new NotChargingWithExpectedPowerReasonTemplate(LocalizationKey)
+        {
+            FormatArguments = FormatArguments?.ToArray(),
+            ReasonEndTime = ReasonEndTime,
+        };
+    }
+
+    public DtoNotChargingWithExpectedPowerReason ToDto(ITextLocalizationService textLocalizationService, CultureInfo culture)
+    {
+        if (textLocalizationService == null)
+        {
+            throw new ArgumentNullException(nameof(textLocalizationService));
+        }
+
+        var template = textLocalizationService.Get<NotChargingWithExpectedPowerReasonLocalizationRegistry>(LocalizationKey, culture, typeof(SharedComponentLocalizationRegistry))
+                       ?? LocalizationKey;
+
+        var formattedReason = (FormatArguments?.Length ?? 0) > 0
+            ? string.Format(culture, template, FormatArguments!)
+            : template;
+
+        return new DtoNotChargingWithExpectedPowerReason(formattedReason, ReasonEndTime);
+    }
+}

--- a/TeslaSolarCharger/Shared/Dtos/Settings/Settings.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Settings/Settings.cs
@@ -32,8 +32,8 @@ public class Settings : ISettings
     /// </summary>
     public ConcurrentDictionary<int, DtoOcppConnectorState> OcppConnectorStates { get; set; } = new();
 
-    public ConcurrentBag<DtoNotChargingWithExpectedPowerReason> GenericNotChargingWithExpectedPowerReasons { get; set; } = new();
-    public ConcurrentDictionary<(int? carId, int? connectorId), List<DtoNotChargingWithExpectedPowerReason>> LoadPointSpecificNotChargingWithExpectedPowerReasons
+    public ConcurrentBag<NotChargingWithExpectedPowerReasonTemplate> GenericNotChargingWithExpectedPowerReasons { get; set; } = new();
+    public ConcurrentDictionary<(int? carId, int? connectorId), List<NotChargingWithExpectedPowerReasonTemplate>> LoadPointSpecificNotChargingWithExpectedPowerReasons
     { get; set; } = new();
 
     public ConcurrentDictionary<int, (int? carId, DateTimeOffset combinationTimeStamp)> ManualSetLoadPointCarCombinations { get; set; } = new();

--- a/TeslaSolarCharger/Shared/Localization/Registries/Server/NotChargingWithExpectedPowerReasonLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Server/NotChargingWithExpectedPowerReasonLocalizationRegistry.cs
@@ -1,0 +1,81 @@
+using TeslaSolarCharger.Shared.Localization;
+
+namespace TeslaSolarCharger.Shared.Localization.Registries.Server;
+
+public class NotChargingWithExpectedPowerReasonLocalizationRegistry : TextLocalizationRegistry<NotChargingWithExpectedPowerReasonLocalizationRegistry>
+{
+    protected override void Configure()
+    {
+        Register("OCPP connection not established. After a TSC or charger reboot it can take up to 5 minutes until the charger is connected again.",
+            new TextLocalizationTranslation(LanguageCodes.English, "OCPP connection not established. After a TSC or charger reboot it can take up to 5 minutes until the charger is connected again."),
+            new TextLocalizationTranslation(LanguageCodes.German, "OCPP-Verbindung nicht hergestellt. Nach einem Neustart von TSC oder der Wallbox kann es bis zu 5 Minuten dauern, bis die Wallbox wieder verbunden ist."));
+
+        Register("Car is not at home",
+            new TextLocalizationTranslation(LanguageCodes.English, "Car is not at home"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Auto befindet sich nicht zu Hause"));
+
+        Register("Car is not plugged in",
+            new TextLocalizationTranslation(LanguageCodes.English, "Car is not plugged in"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Auto ist nicht eingesteckt"));
+
+        Register("Charging connector is not plugged in",
+            new TextLocalizationTranslation(LanguageCodes.English, "Charging connector is not plugged in"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Ladeanschluss ist nicht eingesteckt"));
+
+        Register("Car is fully charged",
+            new TextLocalizationTranslation(LanguageCodes.English, "Car is fully charged"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Auto ist vollständig geladen"));
+
+        Register("Waiting phase switch cooldown time before starting to charge",
+            new TextLocalizationTranslation(LanguageCodes.English, "Waiting phase switch cooldown time before starting to charge"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Warte auf Abkühlzeit für Phasenumschaltung, bevor mit dem Laden begonnen wird"));
+
+        Register("Waiting for phase increase",
+            new TextLocalizationTranslation(LanguageCodes.English, "Waiting for phase increase"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Warte auf Erhöhung der Phasen"));
+
+        Register("Waiting for phase reduction",
+            new TextLocalizationTranslation(LanguageCodes.English, "Waiting for phase reduction"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Warte auf Reduzierung der Phasen"));
+
+        Register("Waiting for charge stop",
+            new TextLocalizationTranslation(LanguageCodes.English, "Waiting for charge stop"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Warte auf Lade-Stopp"));
+
+        Register("Configured max Soc is reached",
+            new TextLocalizationTranslation(LanguageCodes.English, "Configured max Soc is reached"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Konfigurierte maximale SoC ist erreicht"));
+
+        Register("Car side SOC limit is reached. To start charging, the car side SOC limit needs to be at least {0}% higher than the actual SOC.",
+            new TextLocalizationTranslation(LanguageCodes.English, "Car side SOC limit is reached. To start charging, the car side SOC limit needs to be at least {0}% higher than the actual SOC."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeugseitiges SoC-Limit ist erreicht. Um mit dem Laden zu beginnen, muss das Fahrzeuglimit mindestens {0}% höher als der aktuelle SoC sein."));
+
+        Register("Charging stopped by car, e.g. it is full or its charge limit is reached.",
+            new TextLocalizationTranslation(LanguageCodes.English, "Charging stopped by car, e.g. it is full or its charge limit is reached."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Laden wurde vom Fahrzeug gestoppt, z. B. weil es voll ist oder das Ladeziel erreicht wurde."));
+
+        Register("Waiting for charge start",
+            new TextLocalizationTranslation(LanguageCodes.English, "Waiting for charge start"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Warte auf Lade-Start"));
+
+        Register("Charging stopped because of not enough max combined current.",
+            new TextLocalizationTranslation(LanguageCodes.English, "Charging stopped because of not enough max combined current."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Laden gestoppt, da nicht genug maximale kombinierte Stromstärke verfügbar ist."));
+
+        Register("Charge mode is off or max SoC is reached.",
+            new TextLocalizationTranslation(LanguageCodes.English, "Charge mode is off or max SoC is reached."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Lademodus ist aus oder die maximale SoC ist erreicht."));
+
+        Register("Min Phases or Max Phases is unkown. Check the logs for further details.",
+            new TextLocalizationTranslation(LanguageCodes.English, "Min Phases or Max Phases is unkown. Check the logs for further details."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Minimale oder maximale Phasenanzahl ist unbekannt. Weitere Details stehen im Log."));
+
+        Register("Estimated voltage while charging is unkown. Check the logs for further details.",
+            new TextLocalizationTranslation(LanguageCodes.English, "Estimated voltage while charging is unkown. Check the logs for further details."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Geschätzte Spannung während des Ladens ist unbekannt. Weitere Details stehen im Log."));
+
+        Register("Reserved {0}W for Home battery charging as its SOC ({1}%) is below minimum SOC ({2}%)",
+            new TextLocalizationTranslation(LanguageCodes.English, "Reserved {0}W for Home battery charging as its SOC ({1}%) is below minimum SOC ({2}%)"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Reserviere {0}W zum Laden der Hausbatterie, da ihr SoC ({1}%) unter dem Mindest-SoC ({2}%) liegt."));
+    }
+}

--- a/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using TeslaSolarCharger.Shared.Localization.Contracts;
 using TeslaSolarCharger.Shared.Localization.Registries;
 using TeslaSolarCharger.Shared.Localization.Registries.Components;
 using TeslaSolarCharger.Shared.Localization.Registries.Components.StartPage;
+using TeslaSolarCharger.Shared.Localization.Registries.Server;
 using TeslaSolarCharger.Shared.Localization.Registries.Pages;
 using TeslaSolarCharger.Shared.Resources;
 using TeslaSolarCharger.Shared.Resources.Contracts;
@@ -59,6 +60,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ITextLocalizationRegistry, LoggedErrorsComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, ManualOcppChargingComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, NotChargingAtExpectedPowerReasonsComponentLocalizationRegistry>()
+            .AddSingleton<ITextLocalizationRegistry, NotChargingWithExpectedPowerReasonLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, PowerBufferComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, InstallationInformationLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, MerryChristmasAndHappyNewYearComponentLocalizationRegistry>()


### PR DESCRIPTION
## Summary
- store not-charging reasons as localization-aware templates and translate them per request
- add a shared localization registry for backend reason texts and update DI registration
- update services to supply localization keys and format arguments instead of hard-coded English strings

## Testing
- dotnet build TeslaSolarCharger.sln

------
https://chatgpt.com/codex/tasks/task_e_68ed576028008324ac8f7886a12d5337