### PR TITLE
Update German SoC and SocLimit translations

### DIFF
--- a/TeslaSolarCharger/Shared/Localization/Registries/BaseConfigurationBasePropertyLocalization.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/BaseConfigurationBasePropertyLocalization.cs
@@ -85,7 +85,7 @@ public class BaseConfigurationBasePropertyLocalization : PropertyLocalizationReg
                 "If enabled, when a target Soc is set not only grid prices but also estimated solar power generation is used to schedule charging."),
             new PropertyLocalizationTranslation(LanguageCodes.German,
                 "Vorhergesagte Solarleistung für Ladepläne verwenden",
-                "Wenn aktiviert und ein Ziel-SoC gesetzt ist, werden für die Ladeplanung neben den Netzpreisen auch die prognostizierte Solarleistung berücksichtigt."));
+                "Wenn aktiviert und ein Ziel-Ladestand gesetzt ist, werden für die Ladeplanung neben den Netzpreisen auch die prognostizierte Solarleistung berücksichtigt."));
 
         Register(x => x.ShowEnergyDataOnHome,
             new PropertyLocalizationTranslation(LanguageCodes.English,
@@ -180,39 +180,39 @@ public class BaseConfigurationBasePropertyLocalization : PropertyLocalizationReg
                 "Dynamic Home Battery Min Soc",
                 "If enabled the Home Battery Min Soc is automatically set based on solar predictions to make sure the home battery is fully charged at the end of the day. This setting is only recommended after having solar predictions enabled for at least two weeks."),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Dynamischer Mindest-SoC der Heimbatterie",
-                "Wenn aktiviert, wird der minimale SoC der Heimbatterie automatisch anhand der Solarprognosen festgelegt, damit sie zum Tagesende voll ist. Diese Einstellung wird erst empfohlen, wenn die Solarprognosen mindestens zwei Wochen aktiv waren."));
+                "Dynamischer Mindest-Ladestand der Heimbatterie",
+                "Wenn aktiviert, wird der minimale Ladestand der Heimbatterie automatisch anhand der Solarprognosen festgelegt, damit sie zum Tagesende voll ist. Diese Einstellung wird erst empfohlen, wenn die Solarprognosen mindestens zwei Wochen aktiv waren."));
 
         Register(x => x.HomeBatteryMinSoc,
             new PropertyLocalizationTranslation(LanguageCodes.English,
                 "Home Battery Minimum SoC",
                 "Set the SoC your home battery should get charged to before cars start to use full power. Leave empty if you do not have a home battery"),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Minimaler Heimbatterie-SoC",
-                "Legen Sie fest, bis zu welchem SoC die Heimbatterie geladen wird, bevor Fahrzeuge mit voller Leistung laden. Leer lassen, wenn keine Heimbatterie vorhanden ist."));
+                "Minimaler Ladestand der Heimbatterie",
+                "Legen Sie fest, bis zu welchem Ladestand die Heimbatterie geladen wird, bevor Fahrzeuge mit voller Leistung laden. Leer lassen, wenn keine Heimbatterie vorhanden ist."));
 
         Register(x => x.HomeBatteryMinDynamicMinSoc,
             new PropertyLocalizationTranslation(LanguageCodes.English,
                 "Home Battery Min Dynamic Min Soc",
                 "Reserve that is always set as min SoC."),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Minimaler dynamischer Mindest-SoC der Heimbatterie",
-                "Reserve, die immer als minimaler SoC gesetzt wird."));
+                "Minimaler dynamischer Mindest-Ladestand der Heimbatterie",
+                "Reserve, die immer als minimaler Ladestand gesetzt wird."));
 
         Register(x => x.HomeBatteryMaxDynamicMinSoc,
             new PropertyLocalizationTranslation(LanguageCodes.English,
                 "Home Battery Max Dynamic Min Soc",
                 "Min SoC is never set higher than this value."),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Maximaler dynamischer Mindest-SoC der Heimbatterie",
-                "Der minimale SoC wird nie höher als dieser Wert gesetzt."));
+                "Maximaler dynamischer Mindest-Ladestand der Heimbatterie",
+                "Der minimale Ladestand wird nie höher als dieser Wert gesetzt."));
 
         Register(x => x.DynamicMinSocCalculationBuffer,
             new PropertyLocalizationTranslation(LanguageCodes.English,
                 "Dynamic Min Soc Calculation Buffer",
                 "Used to make sure your home battery does not run out of power even if weather predictions are not correct or your house uses more energy than anticipated."),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Berechnungspuffer für dynamischen Mindest-SoC",
+                "Berechnungspuffer für dynamischen Mindest-Ladestand",
                 "Sorgt dafür, dass die Heimbatterie nicht leer wird, selbst wenn Wetterprognosen falsch liegen oder der Energiebedarf höher als erwartet ist."));
 
         Register(x => x.ForceFullHomeBatteryBySunset,
@@ -229,7 +229,7 @@ public class BaseConfigurationBasePropertyLocalization : PropertyLocalizationReg
                 "Set the power your home battery should charge with as long as SoC is below set minimum SoC. Leave empty if you do not have a home battery"),
             new PropertyLocalizationTranslation(LanguageCodes.German,
                 "Ziel-Ladeleistung der Heimbatterie",
-                "Legen Sie die Leistung fest, mit der die Heimbatterie geladen wird, solange der SoC unter dem Mindestwert liegt. Leer lassen, wenn keine Heimbatterie vorhanden ist."));
+                "Legen Sie die Leistung fest, mit der die Heimbatterie geladen wird, solange der Ladestand unter dem Mindestwert liegt. Leer lassen, wenn keine Heimbatterie vorhanden ist."));
 
         Register(x => x.HomeBatteryDischargingPower,
             new PropertyLocalizationTranslation(LanguageCodes.English,
@@ -252,8 +252,8 @@ public class BaseConfigurationBasePropertyLocalization : PropertyLocalizationReg
                 "Discharge Home Battery To Min Soc During Day",
                 "When enabled TSC discharges the home battery to its Min Soc after sunrise and before sunset. Note: Charging of cars is only started if minimum difference between actual home battery soc and min soc is at least 10%."),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Heimbatterie tagsüber auf Mindest-SoC entladen",
-                "Wenn aktiviert, entlädt TSC die Heimbatterie zwischen Sonnenaufgang und Sonnenuntergang bis zum Mindest-SoC. Hinweis: Das Laden von Fahrzeugen startet erst, wenn die Differenz zwischen aktuellem und minimalem SoC mindestens 10 % beträgt."));
+                "Heimbatterie tagsüber auf Mindest-Ladestand entladen",
+                "Wenn aktiviert, entlädt TSC die Heimbatterie zwischen Sonnenaufgang und Sonnenuntergang bis zum Mindest-Ladestand. Hinweis: Das Laden von Fahrzeugen startet erst, wenn die Differenz zwischen aktuellem und minimalem Ladestand mindestens 10 % beträgt."));
 
         Register(x => x.CarChargeLoss,
             new PropertyLocalizationTranslation(LanguageCodes.English,

--- a/TeslaSolarCharger/Shared/Localization/Registries/CarBasicConfigurationPropertyLocalization.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/CarBasicConfigurationPropertyLocalization.cs
@@ -45,7 +45,7 @@ public class CarBasicConfigurationPropertyLocalization : PropertyLocalizationReg
                 "This value is used to reach a desired SoC in time if on spot price or PVOnly charge mode."),
             new PropertyLocalizationTranslation(LanguageCodes.German,
                 "Nutzbare Energie",
-                "Dieser Wert wird genutzt, um im Spotpreis- oder PV-Only-Modus rechtzeitig einen gewünschten SoC zu erreichen."));
+                "Dieser Wert wird genutzt, um im Spotpreis- oder PV-Only-Modus rechtzeitig einen gewünschten Ladestand zu erreichen."));
 
         Register(x => x.ChargingPriority,
             new PropertyLocalizationTranslation(LanguageCodes.English,

--- a/TeslaSolarCharger/Shared/Localization/Registries/CarChargingTargetPropertyLocalization.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/CarChargingTargetPropertyLocalization.cs
@@ -12,8 +12,8 @@ public class CarChargingTargetPropertyLocalization : PropertyLocalizationRegistr
                 "Discharge Home Battery To Min Soc",
                 "If no Target soc is set, TSC tries to discharge the home battery to its minimum SoC by the target time. If a Target Soc is set, TSC schedules charging to reduce grid usage by reducing the charging speed which your home battery is capable of."),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Heimbatterie auf Mindest-SoC entladen",
-                "Wenn kein Ziel-SoC gesetzt ist, versucht TSC, die Heimbatterie bis zur Zielzeit auf ihren minimalen SoC zu entladen. Ist ein Ziel-SoC definiert, plant TSC das Laden so, dass der Netzbezug reduziert wird und nur die von der Heimbatterie unterstützte Ladeleistung genutzt wird."));
+                "Heimbatterie auf Mindest-Ladestand entladen",
+                "Wenn kein Ziel-Ladestand gesetzt ist, versucht TSC, die Heimbatterie bis zur Zielzeit auf ihren minimalen Ladestand zu entladen. Ist ein Ziel-Ladestand definiert, plant TSC das Laden so, dass der Netzbezug reduziert wird und nur die von der Heimbatterie unterstützte Ladeleistung genutzt wird."));
 
         Register(x => x.RepeatOnMondays,
             new PropertyLocalizationTranslation(LanguageCodes.English,

--- a/TeslaSolarCharger/Shared/Localization/Registries/CarOverviewSettingsPropertyLocalization.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/CarOverviewSettingsPropertyLocalization.cs
@@ -12,15 +12,15 @@ public class CarOverviewSettingsPropertyLocalization : PropertyLocalizationRegis
                 "Min Soc",
                 "Always charge at full speed until this soc even if there is not enough solar power"),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Min-SoC",
-                "Bis zu diesem SoC immer mit voller Leistung laden, auch wenn nicht genügend Solarstrom vorhanden ist."));
+                "Min-Ladestand",
+                "Bis zu diesem Ladestand immer mit voller Leistung laden, auch wenn nicht genügend Solarstrom vorhanden ist."));
 
         Register(x => x.MaxSoc,
             new PropertyLocalizationTranslation(LanguageCodes.English,
                 "Max Soc",
                 "Stop charging at this soc even if there is enough solar power"),
             new PropertyLocalizationTranslation(LanguageCodes.German,
-                "Max-SoC",
-                "Bei diesem SoC den Ladevorgang stoppen, auch wenn genügend Solarstrom vorhanden ist."));
+                "Max-Ladestand",
+                "Bei diesem Ladestand den Ladevorgang stoppen, auch wenn genügend Solarstrom vorhanden ist."));
     }
 }

--- a/TeslaSolarCharger/Shared/Localization/Registries/Components/StartPage/CarDetailsComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Components/StartPage/CarDetailsComponentLocalizationRegistry.cs
@@ -32,7 +32,7 @@ public class CarDetailsComponentLocalizationRegistry : TextLocalizationRegistry<
 
         Register("As this car is not connected via an API you need to manually set the current state of charge. Note: Each time you plugin the car the SoC is reset as TSC does not know how much energy the car used.",
             new TextLocalizationTranslation(LanguageCodes.English, "As this car is not connected via an API you need to manually set the current state of charge. Note: Each time you plugin the car the SoC is reset as TSC does not know how much energy the car used."),
-            new TextLocalizationTranslation(LanguageCodes.German, "Da dieses Auto nicht über eine API verbunden ist, musst du den aktuellen Ladezustand manuell setzen. Hinweis: Jedes Mal, wenn du das Auto einsteckst, wird der SoC zurückgesetzt, da der TSC nicht weiß, wie viel Energie das Auto verbraucht hat."));
+            new TextLocalizationTranslation(LanguageCodes.German, "Da dieses Auto nicht über eine API verbunden ist, musst du den aktuellen Ladezustand manuell setzen. Hinweis: Jedes Mal, wenn du das Auto einsteckst, wird der Ladestand zurückgesetzt, da der TSC nicht weiß, wie viel Energie das Auto verbraucht hat."));
 
         Register("State of Charge",
             new TextLocalizationTranslation(LanguageCodes.English, "State of Charge"),
@@ -60,27 +60,27 @@ public class CarDetailsComponentLocalizationRegistry : TextLocalizationRegistry<
 
         Register("SoC: ",
             new TextLocalizationTranslation(LanguageCodes.English, "SoC: "),
-            new TextLocalizationTranslation(LanguageCodes.German, "SoC: "));
+            new TextLocalizationTranslation(LanguageCodes.German, "Ladestand: "));
 
         Register("Car Limit: ",
             new TextLocalizationTranslation(LanguageCodes.English, "Car Limit: "),
-            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeuggrenze: "));
+            new TextLocalizationTranslation(LanguageCodes.German, "Ladelimit: "));
 
         Register("Failed to update Min SOC: {0}",
             new TextLocalizationTranslation(LanguageCodes.English, "Failed to update Min SOC: {0}"),
-            new TextLocalizationTranslation(LanguageCodes.German, "Min-SoC konnte nicht aktualisiert werden: {0}"));
+            new TextLocalizationTranslation(LanguageCodes.German, "Minimaler Ladestand konnte nicht aktualisiert werden: {0}"));
 
         Register("Min SOC updated successfully.",
             new TextLocalizationTranslation(LanguageCodes.English, "Min SOC updated successfully."),
-            new TextLocalizationTranslation(LanguageCodes.German, "Min-SoC erfolgreich aktualisiert."));
+            new TextLocalizationTranslation(LanguageCodes.German, "Minimaler Ladestand erfolgreich aktualisiert."));
 
         Register("Failed to update Max SOC: {0}",
             new TextLocalizationTranslation(LanguageCodes.English, "Failed to update Max SOC: {0}"),
-            new TextLocalizationTranslation(LanguageCodes.German, "Max-SoC konnte nicht aktualisiert werden: {0}"));
+            new TextLocalizationTranslation(LanguageCodes.German, "Maximaler Ladestand konnte nicht aktualisiert werden: {0}"));
 
         Register("Max SOC updated successfully.",
             new TextLocalizationTranslation(LanguageCodes.English, "Max SOC updated successfully."),
-            new TextLocalizationTranslation(LanguageCodes.German, "Max-SoC erfolgreich aktualisiert."));
+            new TextLocalizationTranslation(LanguageCodes.German, "Maximaler Ladestand erfolgreich aktualisiert."));
 
         Register("Failed to update Charge Mode: {0}",
             new TextLocalizationTranslation(LanguageCodes.English, "Failed to update Charge Mode: {0}"),

--- a/TeslaSolarCharger/Shared/Localization/Registries/Components/StartPage/ChargingTargetConfigurationComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Components/StartPage/ChargingTargetConfigurationComponentLocalizationRegistry.cs
@@ -40,7 +40,7 @@ public class ChargingTargetConfigurationComponentLocalizationRegistry : TextLoca
 
         Register("Target SoC: {0}%",
             new TextLocalizationTranslation(LanguageCodes.English, "Target SoC: {0}%"),
-            new TextLocalizationTranslation(LanguageCodes.German, "Ziel-SoC: {0}%"));
+            new TextLocalizationTranslation(LanguageCodes.German, "Ziel-Ladestand: {0}%"));
 
         Register("Discharge home battery",
             new TextLocalizationTranslation(LanguageCodes.English, "Discharge home battery"),
@@ -72,7 +72,7 @@ public class ChargingTargetConfigurationComponentLocalizationRegistry : TextLoca
 
         Register("Discharge to min SoC",
             new TextLocalizationTranslation(LanguageCodes.English, "Discharge to min SoC"),
-            new TextLocalizationTranslation(LanguageCodes.German, "Bis zum minimalen SoC entladen"));
+            new TextLocalizationTranslation(LanguageCodes.German, "Bis zum minimalen Ladestand entladen"));
 
         Register("Try to not use grid energy by reducing car's charging speed",
             new TextLocalizationTranslation(LanguageCodes.English, "Try to not use grid energy by reducing car's charging speed"),

--- a/TeslaSolarCharger/Shared/Localization/Registries/Components/StartPage/EnergyPredictionComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Components/StartPage/EnergyPredictionComponentLocalizationRegistry.cs
@@ -16,7 +16,7 @@ public class EnergyPredictionComponentLocalizationRegistry : TextLocalizationReg
 
         Register("Home Battery SoC %",
             new TextLocalizationTranslation(LanguageCodes.English, "Home Battery SoC %"),
-            new TextLocalizationTranslation(LanguageCodes.German, "Heimspeicher-SoC %"));
+            new TextLocalizationTranslation(LanguageCodes.German, "Heimspeicher-Ladestand %"));
 
         Register("Battery Discharge ({0} kWh)",
             new TextLocalizationTranslation(LanguageCodes.English, "Battery Discharge ({0} kWh)"),

--- a/TeslaSolarCharger/Shared/Localization/Registries/Server/NotChargingWithExpectedPowerReasonLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Server/NotChargingWithExpectedPowerReasonLocalizationRegistry.cs
@@ -44,11 +44,11 @@ public class NotChargingWithExpectedPowerReasonLocalizationRegistry : TextLocali
 
         Register("Configured max Soc is reached",
             new TextLocalizationTranslation(LanguageCodes.English, "Configured max Soc is reached"),
-            new TextLocalizationTranslation(LanguageCodes.German, "Konfigurierte maximale SoC ist erreicht"));
+            new TextLocalizationTranslation(LanguageCodes.German, "Konfigurierter maximaler Ladestand ist erreicht"));
 
         Register("Car side SOC limit is reached. To start charging, the car side SOC limit needs to be at least {0}% higher than the actual SOC.",
             new TextLocalizationTranslation(LanguageCodes.English, "Car side SOC limit is reached. To start charging, the car side SOC limit needs to be at least {0}% higher than the actual SOC."),
-            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeugseitiges SoC-Limit ist erreicht. Um mit dem Laden zu beginnen, muss das Fahrzeuglimit mindestens {0}% höher als der aktuelle SoC sein."));
+            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeugseitiges Ladelimit ist erreicht. Um mit dem Laden zu beginnen, muss das Fahrzeuglimit mindestens {0}% höher als der aktuelle Ladestand sein."));
 
         Register("Charging stopped by car, e.g. it is full or its charge limit is reached.",
             new TextLocalizationTranslation(LanguageCodes.English, "Charging stopped by car, e.g. it is full or its charge limit is reached."),
@@ -64,7 +64,7 @@ public class NotChargingWithExpectedPowerReasonLocalizationRegistry : TextLocali
 
         Register("Charge mode is off or max SoC is reached.",
             new TextLocalizationTranslation(LanguageCodes.English, "Charge mode is off or max SoC is reached."),
-            new TextLocalizationTranslation(LanguageCodes.German, "Lademodus ist aus oder die maximale SoC ist erreicht."));
+            new TextLocalizationTranslation(LanguageCodes.German, "Lademodus ist aus oder der maximale Ladestand ist erreicht."));
 
         Register("Min Phases or Max Phases is unkown. Check the logs for further details.",
             new TextLocalizationTranslation(LanguageCodes.English, "Min Phases or Max Phases is unkown. Check the logs for further details."),
@@ -76,6 +76,6 @@ public class NotChargingWithExpectedPowerReasonLocalizationRegistry : TextLocali
 
         Register("Reserved {0}W for Home battery charging as its SOC ({1}%) is below minimum SOC ({2}%)",
             new TextLocalizationTranslation(LanguageCodes.English, "Reserved {0}W for Home battery charging as its SOC ({1}%) is below minimum SOC ({2}%)"),
-            new TextLocalizationTranslation(LanguageCodes.German, "Reserviere {0}W zum Laden der Hausbatterie, da ihr SoC ({1}%) unter dem Mindest-SoC ({2}%) liegt."));
+            new TextLocalizationTranslation(LanguageCodes.German, "Reserviere {0}W zum Laden der Hausbatterie, da ihr Ladestand ({1}%) unter dem Mindest-Ladestand ({2}%) liegt."));
     }
 }


### PR DESCRIPTION
## Summary
- update German localization strings to use "Ladestand" for SoC-related texts
- translate car-side limit messaging to "Ladelimit" for SocLimit references across the UI

## Testing
- not run (localization changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ee748cb1608324827af24bffeef7a6