### PR TITLE
Localize car dialogs

### DIFF
--- a/TeslaSolarCharger/Client/Dialogs/AddCarDialog.razor
+++ b/TeslaSolarCharger/Client/Dialogs/AddCarDialog.razor
@@ -1,9 +1,13 @@
-﻿@using TeslaSolarCharger.Shared.Dtos
+@using TeslaSolarCharger.Shared.Dtos
 @using TeslaSolarCharger.Shared.Enums
+@using TeslaSolarCharger.Shared.Localization.Contracts
+@using TeslaSolarCharger.Shared.Localization.Registries
+@using TeslaSolarCharger.Shared.Localization.Registries.Pages
 
 @inject HttpClient HttpClient
+@inject ITextLocalizationService TextLocalizer
 
-<h3>AddCarDialog</h3>
+<h3>@T("Add car")</h3>
 
 @if (_fleetApiTokenState == default)
 {
@@ -14,8 +18,8 @@ else if (_fleetApiTokenState != TokenState.UpToDate)
     <MudAlert Severity="Severity.Error"
               NoIcon="true"
               ContentAlignment="HorizontalAlignment.Left">
-        <h4>Tesla Fleet API Token is not valid.</h4>
-        Go to <MudLink Href="/cloudconnection">Cloud Connection</MudLink> and Generate a Tesla Fleet API Token.
+        <h4>@T("Tesla Fleet API Token is not valid.")</h4>
+        @T("Go to ")<MudLink Href="/cloudconnection">@T("Cloud Connection")</MudLink>@T(" and generate a Tesla Fleet API Token.")
     </MudAlert>
 }
 else
@@ -27,6 +31,10 @@ else
 
 
     private TokenState? _fleetApiTokenState;
+
+    private string T(string key) =>
+        TextLocalizer.Get<CarSettingsPageLocalizationRegistry>(key, typeof(SharedComponentLocalizationRegistry))
+        ?? key;
 
     protected override async Task OnInitializedAsync()
     {

--- a/TeslaSolarCharger/Client/Dialogs/ChargingTargetConfigurationDialog.razor
+++ b/TeslaSolarCharger/Client/Dialogs/ChargingTargetConfigurationDialog.razor
@@ -1,7 +1,11 @@
 @using TeslaSolarCharger.Client.Wrapper
 @using TeslaSolarCharger.Shared.Dtos.Home
+@using TeslaSolarCharger.Shared.Localization.Contracts
+@using TeslaSolarCharger.Shared.Localization.Registries
+@using TeslaSolarCharger.Shared.Localization.Registries.Components.StartPage
 
 @inject ISnackbar Snackbar
+@inject ITextLocalizationService TextLocalizer
 @implements IDisposable
 
 <MudDialog>
@@ -11,8 +15,8 @@
             <MudAlert Severity="Severity.Warning"
                       NoIcon="true"
                       ContentAlignment="HorizontalAlignment.Left">
-                <h5>Saved in different timezone</h5>
-                This element was saved in a different timezone than your device currently is in. The timezone is set when adding a new target, so to fix this issue, you need to delete this target and readd it.
+                <h5>@T("Saved in different timezone")</h5>
+                @T("This element was saved in a different timezone than your device currently is in. The timezone is set when adding a new target, so to fix this issue, you need to delete this target and readd it.")
             </MudAlert>
         }
 
@@ -32,7 +36,7 @@
                           Clearable="true"></GenericInput>
             <GenericInput For="() => Target.Item.TargetTime"></GenericInput>
             <div class="fw-semibold mt-2 ml-2">
-                Repeat on:
+                @T("Repeat on:")
             </div>
             <div class="d-flex flex-wrap gap-2">
                 <GenericInput For="() => Target.Item.RepeatOnMondays"></GenericInput>
@@ -46,7 +50,7 @@
         </EditFormComponent>
     </DialogContent>
     <DialogActions>
-        <MudButton Variant="Variant.Text" OnClick="Cancel" Disabled="IsSaving">Cancel</MudButton>
+        <MudButton Variant="Variant.Text" OnClick="Cancel" Disabled="IsSaving">@T("Cancel")</MudButton>
         <MudButton Variant="Variant.Text"
                    Color="Color.Primary"
                    ButtonType="ButtonType.Button"
@@ -56,11 +60,11 @@
             @if (IsSaving)
             {
                 <MudProgressCircular Class="ms-n1" Size="Size.Small" Indeterminate="true" />
-                <MudText Class="ms-2">Processing</MudText>
+                <MudText Class="ms-2">@T("Processing")</MudText>
             }
             else
             {
-                <MudText>Save</MudText>
+                <MudText>@T("Save")</MudText>
             }
         </MudButton>
     </DialogActions>
@@ -97,6 +101,10 @@
         !string.IsNullOrWhiteSpace(CurrentTimeZone) &&
         !string.Equals(Target.Item.ClientTimeZone, CurrentTimeZone, System.StringComparison.OrdinalIgnoreCase);
 
+    private string T(string key) =>
+        TextLocalizer.Get<ChargingTargetConfigurationComponentLocalizationRegistry>(key, typeof(SharedComponentLocalizationRegistry))
+        ?? key;
+
     private void Cancel() => MudDialog.Cancel();
 
     private async Task SubmitFormAsync()
@@ -125,7 +133,7 @@
 
     private void HandleSuccessfulSubmit(DtoCarChargingTarget _)
     {
-        Snackbar.Add("Saved.", Severity.Success);
+        Snackbar.Add(T("Saved."), Severity.Success);
         MudDialog.Close(DialogResult.Ok(true));
     }
 

--- a/TeslaSolarCharger/Shared/Localization/Registries/Components/StartPage/ChargingTargetConfigurationComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Components/StartPage/ChargingTargetConfigurationComponentLocalizationRegistry.cs
@@ -42,6 +42,10 @@ public class ChargingTargetConfigurationComponentLocalizationRegistry : TextLoca
             new TextLocalizationTranslation(LanguageCodes.English, "Target SoC: {0}%"),
             new TextLocalizationTranslation(LanguageCodes.German, "Ziel-Ladestand: {0}%"));
 
+        Register("Repeat on:",
+            new TextLocalizationTranslation(LanguageCodes.English, "Repeat on:"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Wiederholen am:"));
+
         Register("Discharge home battery",
             new TextLocalizationTranslation(LanguageCodes.English, "Discharge home battery"),
             new TextLocalizationTranslation(LanguageCodes.German, "Heimspeicher entladen"));

--- a/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
@@ -38,6 +38,18 @@ public class CarSettingsPageLocalizationRegistry : TextLocalizationRegistry<CarS
             new TextLocalizationTranslation(LanguageCodes.English, "Add car (non Tesla)"),
             new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeug hinzufügen (kein Tesla)"));
 
+        Register("Add car",
+            new TextLocalizationTranslation(LanguageCodes.English, "Add car"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeug hinzufügen"));
+
+        Register("Tesla Fleet API Token is not valid.",
+            new TextLocalizationTranslation(LanguageCodes.English, "Tesla Fleet API Token is not valid."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Tesla Fleet API Token ist nicht gültig."));
+
+        Register(" and generate a Tesla Fleet API Token.",
+            new TextLocalizationTranslation(LanguageCodes.English, " and generate a Tesla Fleet API Token."),
+            new TextLocalizationTranslation(LanguageCodes.German, " und generiere ein Tesla Fleet API Token."));
+
         Register("Current below 6A not recommended",
             new TextLocalizationTranslation(LanguageCodes.English, "Current below 6A not recommended"),
             new TextLocalizationTranslation(LanguageCodes.German, "Stromstärke unter 6A nicht empfohlen"));

--- a/TeslaSolarCharger/Shared/Localization/Registries/SharedComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/SharedComponentLocalizationRegistry.cs
@@ -14,6 +14,14 @@ public class SharedComponentLocalizationRegistry : TextLocalizationRegistry<Shar
             new TextLocalizationTranslation(LanguageCodes.English, "Save"),
             new TextLocalizationTranslation(LanguageCodes.German, "Speichern"));
 
+        Register("Cancel",
+            new TextLocalizationTranslation(LanguageCodes.English, "Cancel"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Abbrechen"));
+
+        Register("Processing",
+            new TextLocalizationTranslation(LanguageCodes.English, "Processing"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Wird verarbeitet"));
+
         Register("Saved.",
             new TextLocalizationTranslation(LanguageCodes.English, "Saved."),
             new TextLocalizationTranslation(LanguageCodes.German, "Gespeichert."));


### PR DESCRIPTION
## Summary
- localize the add car dialog and reuse shared translations for its status messaging
- localize the charging target configuration dialog and hook it into shared localization services
- extend localization registries with the dialog strings and shared button labels

## Testing
- dotnet build TeslaSolarCharger.sln

------
https://chatgpt.com/codex/tasks/task_e_68ee79ba74408324a7b64f515f650b9b