### PR TITLE
Refactor PV value handling into per-device histories

### DIFF
--- a/TeslaSolarCharger.Tests/TestBase.cs
+++ b/TeslaSolarCharger.Tests/TestBase.cs
@@ -18,6 +18,8 @@ using TeslaSolarCharger.Server.Contracts;
 using TeslaSolarCharger.Server.Resources.PossibleIssues;
 using TeslaSolarCharger.Server.Resources.PossibleIssues.Contracts;
 using TeslaSolarCharger.Shared.Contracts;
+using TeslaSolarCharger.Shared.Dtos.Contracts;
+using TeslaSolarCharger.Shared.Dtos.Settings;
 using TeslaSolarCharger.Shared.Resources.Contracts;
 using TeslaSolarCharger.Shared.TimeProviding;
 using TeslaSolarCharger.Tests.Data;
@@ -85,6 +87,10 @@ public class TestBase : IDisposable
                 b.RegisterType<FakeDateTimeProvider>();
                 //b.Register((_, _) => _fake.Resolve<IDateTimeProvider>());
             });
+
+        var settingsMock = Mock.Mock<ISettings>();
+        settingsMock.SetupGet(s => s.SolarDevices)
+            .Returns(new ConcurrentDictionary<SolarDeviceKey, SolarDeviceState>());
 
         // In-memory database only exists while the connection is open
         var connection = new SqliteConnection("DataSource=:memory:");

--- a/TeslaSolarCharger/Shared/Contracts/IConfigurationWrapper.cs
+++ b/TeslaSolarCharger/Shared/Contracts/IConfigurationWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
+using TeslaSolarCharger.Shared.Dtos.Settings;
 
 namespace TeslaSolarCharger.Shared.Contracts;
 
@@ -7,6 +8,7 @@ public interface IConfigurationWrapper
     string CarConfigFileFullName();
     TimeSpan ChargingValueJobUpdateIntervall();
     TimeSpan PvValueJobUpdateIntervall();
+    TimeSpan GetSolarDeviceRefreshInterval(SolarDeviceKey deviceKey, TimeSpan fallback);
     string MqqtClientId();
     string? MosquitoServer();
     string? CurrentPowerToGridUrl();

--- a/TeslaSolarCharger/Shared/Dtos/Contracts/ISettings.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Contracts/ISettings.cs
@@ -1,15 +1,21 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using TeslaSolarCharger.Shared.Dtos.Home;
 using TeslaSolarCharger.Shared.Dtos.Settings;
+using TeslaSolarCharger.SharedModel.Enums;
 
 namespace TeslaSolarCharger.Shared.Dtos.Contracts;
 
 public interface ISettings
 {
-    int? InverterPower { get; set; }
-    int? Overage { get; set; }
-    int? HomeBatterySoc { get; set; }
-    int? HomeBatteryPower { get; set; }
+    ConcurrentDictionary<SolarDeviceKey, SolarDeviceState> SolarDevices { get; }
+
+    double? GetAverageValue(ValueUsage usage, TimeSpan window, DateTimeOffset? now = null);
+
+    int? InverterPower { get; }
+    int? Overage { get; }
+    int? HomeBatterySoc { get; }
+    int? HomeBatteryPower { get; }
     bool ControlledACarAtLastCycle { get; set; }
     DateTimeOffset LastPvValueUpdate { get; set; }
     int? AverageHomeGridVoltage { get; set; }

--- a/TeslaSolarCharger/Shared/Dtos/Settings/SolarDeviceKey.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Settings/SolarDeviceKey.cs
@@ -1,0 +1,50 @@
+using System.Globalization;
+
+namespace TeslaSolarCharger.Shared.Dtos.Settings;
+
+public readonly record struct SolarDeviceKey
+{
+    public SolarDeviceKey(SolarDeviceType deviceType, int configurationId, string? customIdentifier = null)
+    {
+        DeviceType = deviceType;
+        ConfigurationId = configurationId;
+        CustomIdentifier = customIdentifier;
+    }
+
+    public SolarDeviceType DeviceType { get; }
+
+    public int ConfigurationId { get; }
+
+    public string? CustomIdentifier { get; }
+
+    public static SolarDeviceKey ForRest(int configurationId) => new(SolarDeviceType.Rest, configurationId);
+
+    public static SolarDeviceKey ForModbus(int configurationId) => new(SolarDeviceType.Modbus, configurationId);
+
+    public static SolarDeviceKey ForMqtt(int configurationId) => new(SolarDeviceType.Mqtt, configurationId);
+
+    public static SolarDeviceKey ForFake(string identifier) => new(SolarDeviceType.Fake, 0, identifier);
+
+    /// <summary>
+    /// Returns a stable key that can be used inside configuration sources (e.g. environment variables).
+    /// </summary>
+    public string ToConfigurationKey()
+    {
+        if (string.IsNullOrWhiteSpace(CustomIdentifier))
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0}_{1}", DeviceType, ConfigurationId);
+        }
+
+        return string.Format(CultureInfo.InvariantCulture, "{0}_{1}_{2}", DeviceType, ConfigurationId, CustomIdentifier);
+    }
+
+    public override string ToString()
+    {
+        if (string.IsNullOrWhiteSpace(CustomIdentifier))
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0}:{1}", DeviceType, ConfigurationId);
+        }
+
+        return string.Format(CultureInfo.InvariantCulture, "{0}:{1}:{2}", DeviceType, ConfigurationId, CustomIdentifier);
+    }
+}

--- a/TeslaSolarCharger/Shared/Dtos/Settings/SolarDeviceState.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Settings/SolarDeviceState.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TeslaSolarCharger.SharedModel.Enums;
+
+namespace TeslaSolarCharger.Shared.Dtos.Settings;
+
+public class SolarDeviceState
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<ValueUsage, DtoHistoricValue<int?>> _histories = new();
+
+    public SolarDeviceState(SolarDeviceKey key, string name, TimeSpan refreshInterval)
+    {
+        DeviceKey = key;
+        Name = name;
+        UpdateRefreshInterval(refreshInterval);
+    }
+
+    public SolarDeviceKey DeviceKey { get; }
+
+    public string Name { get; }
+
+    public TimeSpan RefreshInterval { get; private set; }
+
+    public void UpdateRefreshInterval(TimeSpan refreshInterval)
+    {
+        if (refreshInterval <= TimeSpan.Zero)
+        {
+            refreshInterval = TimeSpan.FromSeconds(1);
+        }
+
+        RefreshInterval = refreshInterval;
+    }
+
+    public void UpdateHistory(ValueUsage usage, DateTimeOffset timestamp, int? value, int minimumCapacity)
+    {
+        lock (_gate)
+        {
+            var capacity = Math.Max(1, minimumCapacity);
+            if (!_histories.TryGetValue(usage, out var history))
+            {
+                history = new DtoHistoricValue<int?>(timestamp, value, capacity);
+                _histories[usage] = history;
+                return;
+            }
+
+            history.SetCapacity(capacity);
+            history.Update(timestamp, value);
+        }
+    }
+
+    public int? GetCurrentValue(ValueUsage usage)
+    {
+        lock (_gate)
+        {
+            if (_histories.TryGetValue(usage, out var history))
+            {
+                return history.Value;
+            }
+
+            return null;
+        }
+    }
+
+    public DateTimeOffset? GetCurrentTimestamp(ValueUsage usage)
+    {
+        lock (_gate)
+        {
+            if (_histories.TryGetValue(usage, out var history))
+            {
+                return history.Timestamp;
+            }
+
+            return null;
+        }
+    }
+
+    public IReadOnlyList<TimedValue<int?>> GetHistorySnapshot(ValueUsage usage)
+    {
+        lock (_gate)
+        {
+            if (_histories.TryGetValue(usage, out var history))
+            {
+                return history.History.ToList();
+            }
+
+            return Array.Empty<TimedValue<int?>>();
+        }
+    }
+
+    public IReadOnlyList<TimedValue<int?>> GetHistorySnapshot(ValueUsage usage, TimeSpan window, DateTimeOffset? now = null)
+    {
+        if (window <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(window));
+        }
+
+        var effectiveNow = now ?? DateTimeOffset.UtcNow;
+        var cutoff = effectiveNow - window;
+
+        lock (_gate)
+        {
+            if (!_histories.TryGetValue(usage, out var history))
+            {
+                return Array.Empty<TimedValue<int?>>();
+            }
+
+            return history.History
+                .Where(sample => sample.Timestamp >= cutoff)
+                .ToList();
+        }
+    }
+
+    public double? GetAverageValue(ValueUsage usage, TimeSpan window, DateTimeOffset? now = null)
+    {
+        var snapshot = GetHistorySnapshot(usage, window, now);
+        if (snapshot.Count == 0)
+        {
+            return null;
+        }
+
+        double sum = 0;
+        var count = 0;
+
+        foreach (var sample in snapshot)
+        {
+            if (!sample.Value.HasValue)
+            {
+                continue;
+            }
+
+            sum += sample.Value.Value;
+            count++;
+        }
+
+        return count == 0 ? null : sum / count;
+    }
+}

--- a/TeslaSolarCharger/Shared/Dtos/Settings/SolarDeviceType.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Settings/SolarDeviceType.cs
@@ -1,0 +1,9 @@
+namespace TeslaSolarCharger.Shared.Dtos.Settings;
+
+public enum SolarDeviceType
+{
+    Rest,
+    Modbus,
+    Mqtt,
+    Fake,
+}

--- a/TeslaSolarCharger/Shared/Wrappers/ConfigurationWrapper.cs
+++ b/TeslaSolarCharger/Shared/Wrappers/ConfigurationWrapper.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using TeslaSolarCharger.Shared.Contracts;
 using TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
 using TeslaSolarCharger.Shared.Dtos.Contracts;
+using TeslaSolarCharger.Shared.Dtos.Settings;
 using TeslaSolarCharger.Shared.Enums;
 
 [assembly: InternalsVisibleTo("TeslaSolarCharger.Tests")]
@@ -363,6 +364,26 @@ public class ConfigurationWrapper(
             value = minimum;
         }
         return value;
+    }
+
+    public TimeSpan GetSolarDeviceRefreshInterval(SolarDeviceKey deviceKey, TimeSpan fallback)
+    {
+        var minimum = TimeSpan.FromSeconds(1);
+        var environmentVariableName = $"SolarDeviceRefreshIntervalSeconds__{deviceKey.ToConfigurationKey()}";
+        var configuredSeconds = configuration.GetValue<int?>(environmentVariableName);
+
+        if (!configuredSeconds.HasValue || configuredSeconds.Value <= 0)
+        {
+            return fallback < minimum ? minimum : fallback;
+        }
+
+        var configured = TimeSpan.FromSeconds(configuredSeconds.Value);
+        if (configured < minimum)
+        {
+            configured = minimum;
+        }
+
+        return configured;
     }
 
     public string MqqtClientId()


### PR DESCRIPTION
## Summary
- abstract PV data collection into device-specific handlers with configurable refresh cadences
- store per-device histories via `SolarDeviceState` and update `Settings`/`ISettings` to surface aggregated readings
- add helpers to access history slices and compute average solar values over a window, enabling future smoothing logic
- extend the configuration wrapper for per-device intervals and adjust supporting tests

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68ef88eb160083248a8f28e7e088a6bd