### PR TITLE
Use translation keys in BaseConfiguration page

### DIFF
--- a/TeslaSolarCharger/Client/Pages/BaseConfiguration.razor
+++ b/TeslaSolarCharger/Client/Pages/BaseConfiguration.razor
@@ -3,6 +3,7 @@
 @using TeslaSolarCharger.Client.Wrapper
 @using TeslaSolarCharger.Shared.Dtos.BaseConfiguration
 @using TeslaSolarCharger.Shared.Dtos
+@using TeslaSolarCharger.Shared.Localization
 @using TeslaSolarCharger.Shared.Localization.Contracts
 @using TeslaSolarCharger.Shared.Localization.Registries
 @using TeslaSolarCharger.Shared.Localization.Registries.Pages
@@ -12,9 +13,9 @@
 @inject ITextLocalizationService TextLocalizer
 
 
-<PageTitle>@T("Base Configuration")</PageTitle>
+<PageTitle>@T(TranslationKeys.BaseConfigurationPageTitle)</PageTitle>
 
-<h1>@T("Base Configuration")</h1>
+<h1>@T(TranslationKeys.BaseConfigurationPageTitle)</h1>
 
 @if (_dtoBaseConfiguration == null)
 {
@@ -25,10 +26,10 @@ else
     <EditFormComponent T="DtoBaseConfiguration" WrappedElement="@(_dtoBaseConfiguration)"
                        OnAfterSuccessfullSubmit="ShowSuccessMessage"
                        SubmitUrl="@("api/BaseConfiguration/UpdateBaseConfiguration")">
-        <h3>@T("General:")</h3>
+        <h3>@T(TranslationKeys.BaseConfigurationGeneralSectionTitle)</h3>
         <GenericInput For="() => _dtoBaseConfiguration.Item.MaxCombinedCurrent" />
         <hr />
-        <h3>@T("TeslaMate:")</h3>
+        <h3>@T(TranslationKeys.BaseConfigurationTeslaMateSectionTitle)</h3>
         <GenericInput T="bool"
         For="() => _dtoBaseConfiguration.Item.UseTeslaMateIntegration"
         OnValueChanged="_ => InvokeAsync(StateHasChanged)"></GenericInput>
@@ -46,15 +47,15 @@ else
         }
 
 
-        <h3>@T("Home Geofence")</h3>
+        <h3>@T(TranslationKeys.BaseConfigurationHomeGeofenceSectionTitle)</h3>
         <div class="mb-3">
             <MapComponent Longitude="_dtoBaseConfiguration.Item.HomeGeofenceLongitude"
             Latitude="_dtoBaseConfiguration.Item.HomeGeofenceLatitude"
             Radius="_dtoBaseConfiguration.Item.HomeGeofenceRadius"
             LatitudeChanged="@(newLatitude => _dtoBaseConfiguration.Item.HomeGeofenceLatitude = newLatitude)"
-            LongitudeChanged="@(newLongitude => { _dtoBaseConfiguration.Item.HomeGeofenceLongitude = newLongitude; Snackbar.Add(T("To update the location, click the save button on the bottom of the page"), Severity.Info); })"></MapComponent>
+            LongitudeChanged="@(newLongitude => { _dtoBaseConfiguration.Item.HomeGeofenceLongitude = newLongitude; Snackbar.Add(T(TranslationKeys.LocationUpdateInfoText), Severity.Info); })"></MapComponent>
 
-            <small class="form-text text-muted">@T("Click on the map to select your home geofence. Within that area TSC will regulate the charging power.")</small>
+            <small class="form-text text-muted">@T(TranslationKeys.BaseConfigurationHomeGeofenceHint)</small>
         </div>
 
         <GenericInput For="() => _dtoBaseConfiguration.Item.HomeGeofenceRadius" />
@@ -90,9 +91,9 @@ else
         <MqttValueConfigurationComponent />
 
         <div class="shadow p-3 mb-5 bg-white rounded">
-            <h3>@T("Telegram:")</h3>
-            <a href="https://github.com/pkuehnel/TeslaSolarCharger#telegram-integration" target="_blank">@T("How to set up Telegram")</a>
-            <div>@T("Note: The Telegram bot for now only sends messages if something is not working. E.g. The car does not respond to commands, solar power values can not be refreshed,...")</div>
+            <h3>@T(TranslationKeys.BaseConfigurationTelegramSectionTitle)</h3>
+            <a href="https://github.com/pkuehnel/TeslaSolarCharger#telegram-integration" target="_blank">@T(TranslationKeys.BaseConfigurationHowToSetupTelegramLinkText)</a>
+            <div>@T(TranslationKeys.BaseConfigurationTelegramBotNote)</div>
             <GenericInput T="string?"
             For="() => _dtoBaseConfiguration.Item.TelegramBotKey"
             OnValueChanged="@(_ => _telegramSettingsChanged = true)"></GenericInput>
@@ -100,20 +101,20 @@ else
             For="() => _dtoBaseConfiguration.Item.TelegramChannelId"
             OnValueChanged="@(_ => _telegramSettingsChanged = true)"></GenericInput>
             <GenericInput For="() => _dtoBaseConfiguration.Item.SendStackTraceToTelegram"></GenericInput>
-            <RightAlignedButtonComponent ButtonText='@T("Send test message")'
-            IsDisabled="_telegramSettingsChanged"
-            DisabledToolTipText='@T("You need to save the configuration before testing it.")'
-            OnButtonClicked="_ => SendTelegramTestMessage()"></RightAlignedButtonComponent>
+            <RightAlignedButtonComponent ButtonText='@T(TranslationKeys.BaseConfigurationSendTestMessageButton)'
+                                         IsDisabled="_telegramSettingsChanged"
+                                         DisabledToolTipText='@T(TranslationKeys.BaseConfigurationSaveBeforeTestingTooltip)'
+                                         OnButtonClicked="_ => SendTelegramTestMessage()"></RightAlignedButtonComponent>
         </div>
 
         <MudExpansionPanels>
-            <MudExpansionPanel Text="@T("Advanced settings. Please only change values here if you know what you are doing.")">
+            <MudExpansionPanel Text="@T(TranslationKeys.BaseConfigurationAdvancedSettingsPanelText)">
                 <GenericInput For="() => _dtoBaseConfiguration.Item.UpdateIntervalSeconds" />
                 @if (_dtoBaseConfiguration.Item.SkipPowerChangesOnLastAdjustmentNewerThanSeconds < 25)
                 {
                     <MudAlert Severity="Severity.Warning"
                               ContentAlignment="HorizontalAlignment.Left">
-                        @T("Values below 25 seconds are not recommended and might cause performance issues.")
+                        @T(TranslationKeys.BaseConfigurationLowIntervalWarning)
                     </MudAlert>
                 }
                 <GenericInput T="int"
@@ -165,7 +166,7 @@ else
 
     private void ShowSuccessMessage()
     {
-        Snackbar.Add(T("Saved."), Severity.Success);
+        Snackbar.Add(T(TranslationKeys.BaseConfigurationSavedNotification), Severity.Success);
     }
 
     private async Task SendTelegramTestMessage()
@@ -173,7 +174,7 @@ else
         var result = await HttpClientHelper.SendGetRequestWithSnackbarAsync<DtoValue<string>>("api/Hello/SendTestTelegramMessage");
         if (result == default)
         {
-            Snackbar.Add(T("Could not get result"), Severity.Error);
+            Snackbar.Add(T(TranslationKeys.BaseConfigurationCouldNotGetResult), Severity.Error);
             return;
         }
 

--- a/TeslaSolarCharger/Shared/Localization/Registries/Pages/BaseConfigurationPageLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Pages/BaseConfigurationPageLocalizationRegistry.cs
@@ -6,15 +6,19 @@ public class BaseConfigurationPageLocalizationRegistry : TextLocalizationRegistr
 {
     protected override void Configure()
     {
-        Register("General:",
+        Register(TranslationKeys.BaseConfigurationPageTitle,
+            new TextLocalizationTranslation(LanguageCodes.English, "Base Configuration"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Basiskonfiguration"));
+
+        Register(TranslationKeys.BaseConfigurationGeneralSectionTitle,
             new TextLocalizationTranslation(LanguageCodes.English, "General:"),
             new TextLocalizationTranslation(LanguageCodes.German, "Allgemein:"));
 
-        Register("TeslaMate:",
+        Register(TranslationKeys.BaseConfigurationTeslaMateSectionTitle,
             new TextLocalizationTranslation(LanguageCodes.English, "TeslaMate:"),
             new TextLocalizationTranslation(LanguageCodes.German, "TeslaMate:"));
 
-        Register("Home Geofence",
+        Register(TranslationKeys.BaseConfigurationHomeGeofenceSectionTitle,
             new TextLocalizationTranslation(LanguageCodes.English, "Home Geofence"),
             new TextLocalizationTranslation(LanguageCodes.German, "Home-Geofence"));
 
@@ -22,43 +26,43 @@ public class BaseConfigurationPageLocalizationRegistry : TextLocalizationRegistr
             new TextLocalizationTranslation(LanguageCodes.English, "To update the location, click the save button on the bottom of the page"),
             new TextLocalizationTranslation(LanguageCodes.German, "Um den Standort zu aktualisieren, klicke auf die Schaltfläche zum Speichern am unteren Rand der Seite"));
 
-        Register("Click on the map to select your home geofence. Within that area TSC will regulate the charging power.",
+        Register(TranslationKeys.BaseConfigurationHomeGeofenceHint,
             new TextLocalizationTranslation(LanguageCodes.English, "Click on the map to select your home geofence. Within that area TSC will regulate the charging power."),
             new TextLocalizationTranslation(LanguageCodes.German, "Klicke auf die Karte, um deinen Home-Geofence auszuwählen. Innerhalb dieses Bereichs reguliert TSC die Ladeleistung."));
 
-        Register("Telegram:",
+        Register(TranslationKeys.BaseConfigurationTelegramSectionTitle,
             new TextLocalizationTranslation(LanguageCodes.English, "Telegram:"),
             new TextLocalizationTranslation(LanguageCodes.German, "Telegram:"));
 
-        Register("How to set up Telegram",
+        Register(TranslationKeys.BaseConfigurationHowToSetupTelegramLinkText,
             new TextLocalizationTranslation(LanguageCodes.English, "How to set up Telegram"),
             new TextLocalizationTranslation(LanguageCodes.German, "So richtest du Telegram ein"));
 
-        Register("Note: The Telegram bot for now only sends messages if something is not working. E.g. The car does not respond to commands, solar power values can not be refreshed,...",
+        Register(TranslationKeys.BaseConfigurationTelegramBotNote,
             new TextLocalizationTranslation(LanguageCodes.English, "Note: The Telegram bot for now only sends messages if something is not working. E.g. The car does not respond to commands, solar power values can not be refreshed,..."),
             new TextLocalizationTranslation(LanguageCodes.German, "Hinweis: Der Telegram-Bot sendet aktuell nur Nachrichten, wenn etwas nicht funktioniert. Z. B. wenn das Auto nicht auf Befehle reagiert oder Solarleistungswerte nicht aktualisiert werden können ..."));
 
-        Register("Send test message",
+        Register(TranslationKeys.BaseConfigurationSendTestMessageButton,
             new TextLocalizationTranslation(LanguageCodes.English, "Send test message"),
             new TextLocalizationTranslation(LanguageCodes.German, "Testnachricht senden"));
 
-        Register("You need to save the configuration before testing it.",
+        Register(TranslationKeys.BaseConfigurationSaveBeforeTestingTooltip,
             new TextLocalizationTranslation(LanguageCodes.English, "You need to save the configuration before testing it."),
             new TextLocalizationTranslation(LanguageCodes.German, "Du musst die Konfiguration speichern, bevor du sie testen kannst."));
 
-        Register("Advanced settings. Please only change values here if you know what you are doing.",
+        Register(TranslationKeys.BaseConfigurationAdvancedSettingsPanelText,
             new TextLocalizationTranslation(LanguageCodes.English, "Advanced settings. Please only change values here if you know what you are doing."),
             new TextLocalizationTranslation(LanguageCodes.German, "Erweiterte Einstellungen. Ändere Werte hier nur, wenn du weißt, was du tust."));
 
-        Register("Values below 25 seconds are not recommended and might cause performance issues.",
+        Register(TranslationKeys.BaseConfigurationLowIntervalWarning,
             new TextLocalizationTranslation(LanguageCodes.English, "Values below 25 seconds are not recommended and might cause performance issues."),
             new TextLocalizationTranslation(LanguageCodes.German, "Werte unter 25 Sekunden werden nicht empfohlen und können zu Leistungsproblemen führen."));
 
-        Register("Saved.",
+        Register(TranslationKeys.BaseConfigurationSavedNotification,
             new TextLocalizationTranslation(LanguageCodes.English, "Saved."),
             new TextLocalizationTranslation(LanguageCodes.German, "Gespeichert."));
 
-        Register("Could not get result",
+        Register(TranslationKeys.BaseConfigurationCouldNotGetResult,
             new TextLocalizationTranslation(LanguageCodes.English, "Could not get result"),
             new TextLocalizationTranslation(LanguageCodes.German, "Ergebnis konnte nicht abgerufen werden"));
     }

--- a/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
+++ b/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
@@ -2,5 +2,19 @@
 
 public static class TranslationKeys
 {
-    public static string LocationUpdateInfoText => "LocationUpdateInfoText";
+    public static string BaseConfigurationPageTitle => nameof(BaseConfigurationPageTitle);
+    public static string BaseConfigurationGeneralSectionTitle => nameof(BaseConfigurationGeneralSectionTitle);
+    public static string BaseConfigurationTeslaMateSectionTitle => nameof(BaseConfigurationTeslaMateSectionTitle);
+    public static string BaseConfigurationHomeGeofenceSectionTitle => nameof(BaseConfigurationHomeGeofenceSectionTitle);
+    public static string LocationUpdateInfoText => nameof(LocationUpdateInfoText);
+    public static string BaseConfigurationHomeGeofenceHint => nameof(BaseConfigurationHomeGeofenceHint);
+    public static string BaseConfigurationTelegramSectionTitle => nameof(BaseConfigurationTelegramSectionTitle);
+    public static string BaseConfigurationHowToSetupTelegramLinkText => nameof(BaseConfigurationHowToSetupTelegramLinkText);
+    public static string BaseConfigurationTelegramBotNote => nameof(BaseConfigurationTelegramBotNote);
+    public static string BaseConfigurationSendTestMessageButton => nameof(BaseConfigurationSendTestMessageButton);
+    public static string BaseConfigurationSaveBeforeTestingTooltip => nameof(BaseConfigurationSaveBeforeTestingTooltip);
+    public static string BaseConfigurationAdvancedSettingsPanelText => nameof(BaseConfigurationAdvancedSettingsPanelText);
+    public static string BaseConfigurationLowIntervalWarning => nameof(BaseConfigurationLowIntervalWarning);
+    public static string BaseConfigurationSavedNotification => nameof(BaseConfigurationSavedNotification);
+    public static string BaseConfigurationCouldNotGetResult => nameof(BaseConfigurationCouldNotGetResult);
 }


### PR DESCRIPTION
## Summary
- replace literal localization keys with TranslationKeys constants in BaseConfiguration page
- add strongly-typed entries to BaseConfiguration localization registry

## Testing
- dotnet build TeslaSolarCharger.sln

------
https://chatgpt.com/codex/tasks/task_e_6908e3d8eed8832484588fed577d7286