### PR TITLE
Refactor template value configuration mapping

### DIFF
--- a/TeslaSolarCharger.Services/Services/Template/Contracts/ITemplateValueConfigurationService.cs
+++ b/TeslaSolarCharger.Services/Services/Template/Contracts/ITemplateValueConfigurationService.cs
@@ -1,13 +1,14 @@
 ﻿using System.Linq.Expressions;
 using TeslaSolarCharger.Model.Entities;
 using TeslaSolarCharger.Model.Entities.TeslaSolarCharger;
+using TeslaSolarCharger.Shared.Dtos.TemplateConfiguration;
 
 namespace TeslaSolarCharger.Services.Services.Template.Contracts;
 
 public interface ITemplateValueConfigurationService
 {
-    Task<TDto?> GetAsync<TDto>(int id) where TDto : class;
-    Task<IEnumerable<object>> GetAllAsync(Expression<Func<TemplateValueConfiguration, bool>> predicate);
-    Task<int> SaveAsync<TDto>(TDto dto) where TDto : class;
+    Task<TDto?> GetAsync<TDto>(int id) where TDto : class, ITemplateValueConfigurationDto;
+    Task<IEnumerable<ITemplateValueConfigurationDto>> GetAllAsync(Expression<Func<TemplateValueConfiguration, bool>> predicate);
+    Task<int> SaveAsync<TDto>(TDto dto) where TDto : class, ITemplateValueConfigurationDto;
     Task DeleteAsync(int id);
 }

--- a/TeslaSolarCharger.Services/Services/Template/Infrastructure/Contracts/ITemplateValueConfigurationFactory.cs
+++ b/TeslaSolarCharger.Services/Services/Template/Infrastructure/Contracts/ITemplateValueConfigurationFactory.cs
@@ -1,11 +1,10 @@
-﻿using TeslaSolarCharger.Model.Entities;
-using TeslaSolarCharger.Model.Entities.TeslaSolarCharger;
+﻿using TeslaSolarCharger.Model.Entities.TeslaSolarCharger;
 using TeslaSolarCharger.Shared.Dtos.TemplateConfiguration;
 
 namespace TeslaSolarCharger.Services.Services.Template.Infrastructure.Contracts;
 
 public interface ITemplateValueConfigurationFactory
 {
-    object CreateDto(TemplateValueConfiguration entity);
-    TemplateValueConfiguration CreateEntity(object dto);
+    ITemplateValueConfigurationDto CreateDto(TemplateValueConfiguration entity);
+    TemplateValueConfiguration CreateEntity(ITemplateValueConfigurationDto dto);
 }

--- a/TeslaSolarCharger.Services/Services/Template/TemplateValueConfigurationService.cs
+++ b/TeslaSolarCharger.Services/Services/Template/TemplateValueConfigurationService.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Linq.Expressions;
 using TeslaSolarCharger.Model.Contracts;
-using TeslaSolarCharger.Model.Entities;
 using TeslaSolarCharger.Model.Entities.TeslaSolarCharger;
 using TeslaSolarCharger.Services.Services.Template.Contracts;
 using TeslaSolarCharger.Services.Services.Template.Infrastructure.Contracts;
+using TeslaSolarCharger.Shared.Dtos.TemplateConfiguration;
 
 namespace TeslaSolarCharger.Services.Services.Template;
 
@@ -24,7 +25,7 @@ public class TemplateValueConfigurationService : ITemplateValueConfigurationServ
         _factory = factory;
     }
 
-    public async Task<TDto?> GetAsync<TDto>(int id) where TDto : class
+    public async Task<TDto?> GetAsync<TDto>(int id) where TDto : class, ITemplateValueConfigurationDto
     {
         _logger.LogTrace("{method}({id})", nameof(GetAsync), id);
         var entity = await _context.TemplateValueConfigurations
@@ -37,7 +38,7 @@ public class TemplateValueConfigurationService : ITemplateValueConfigurationServ
         return dto as TDto;
     }
 
-    public async Task<IEnumerable<object>> GetAllAsync(Expression<Func<TemplateValueConfiguration, bool>> predicate)
+    public async Task<IEnumerable<ITemplateValueConfigurationDto>> GetAllAsync(Expression<Func<TemplateValueConfiguration, bool>> predicate)
     {
         _logger.LogTrace("{method}({predicate})", nameof(GetAllAsync), predicate);
         var entities = await _context.TemplateValueConfigurations
@@ -47,7 +48,7 @@ public class TemplateValueConfigurationService : ITemplateValueConfigurationServ
         return entities.Select(e => _factory.CreateDto(e));
     }
 
-    public async Task<int> SaveAsync<TDto>(TDto dto) where TDto : class
+    public async Task<int> SaveAsync<TDto>(TDto dto) where TDto : class, ITemplateValueConfigurationDto
     {
         _logger.LogTrace("{method}({@dto})", nameof(SaveAsync), dto);
         var entity = _factory.CreateEntity(dto);

--- a/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/DtoTemplateValueConfigurationBase.cs
+++ b/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/DtoTemplateValueConfigurationBase.cs
@@ -3,7 +3,7 @@ using TeslaSolarCharger.SharedModel.Enums;
 
 namespace TeslaSolarCharger.Shared.Dtos.TemplateConfiguration;
 
-public abstract class DtoTemplateValueConfiguration<TConfig> where TConfig : class
+public abstract class DtoTemplateValueConfiguration<TConfig> : ITemplateValueConfigurationDto where TConfig : class
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;

--- a/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/ITemplateValueConfigurationDto.cs
+++ b/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/ITemplateValueConfigurationDto.cs
@@ -1,0 +1,12 @@
+using TeslaSolarCharger.SharedModel.Enums;
+
+namespace TeslaSolarCharger.Shared.Dtos.TemplateConfiguration;
+
+public interface ITemplateValueConfigurationDto
+{
+    int Id { get; set; }
+    string Name { get; set; }
+    int ConfigurationVersion { get; set; }
+    int? MinRefreshIntervalMilliseconds { get; set; }
+    TemplateValueGatherType GatherType { get; }
+}


### PR DESCRIPTION
## Summary
- introduce a shared ITemplateValueConfigurationDto contract and implement it in the template DTO base
- refactor the template value configuration factory to use strongly typed converters instead of reflection
- update service contracts and implementation to return typed DTOs for easier template expansion

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f26651cc83249077e0bcff92ab2b)