### PR TITLE
Introduce car data provider orchestrator pattern

### DIFF
--- a/TeslaSolarCharger/Server/Scheduling/Jobs/VehicleDataRefreshJob.cs
+++ b/TeslaSolarCharger/Server/Scheduling/Jobs/VehicleDataRefreshJob.cs
@@ -4,11 +4,11 @@ using TeslaSolarCharger.Server.Services.Contracts;
 namespace TeslaSolarCharger.Server.Scheduling.Jobs;
 
 [DisallowConcurrentExecution]
-public class VehicleDataRefreshJob(ILogger<VehicleDataRefreshJob> logger, ITeslaFleetApiService service) : IJob
+public class VehicleDataRefreshJob(ILogger<VehicleDataRefreshJob> logger, ICarDataProviderOrchestrator orchestrator) : IJob
 {
     public async Task Execute(IJobExecutionContext context)
     {
         logger.LogTrace("{method}({context})", nameof(Execute), context);
-        await service.RefreshCarData().ConfigureAwait(false);
+        await orchestrator.RefreshAllCarData().ConfigureAwait(false);
     }
 }

--- a/TeslaSolarCharger/Server/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Server/ServiceCollectionExtensions.cs
@@ -127,6 +127,8 @@ public static class ServiceCollectionExtensions
             .AddTransient<IIndexService, IndexService>()
             .AddTransient<ISpotPriceService, SpotPriceService>()
             .AddTransient<ITeslaFleetApiService, TeslaFleetApiService>()
+            .AddTransient<ICarDataProvider, TeslaCarDataProvider>()
+            .AddTransient<ICarDataProviderOrchestrator, CarDataProviderOrchestrator>()
             .AddTransient<ITokenHelper, TokenHelper>()
             .AddTransient<ITscConfigurationService, TscConfigurationService>()
             .AddTransient<IBackendApiService, BackendApiService>()

--- a/TeslaSolarCharger/Server/Services/CarDataProviderOrchestrator.cs
+++ b/TeslaSolarCharger/Server/Services/CarDataProviderOrchestrator.cs
@@ -1,0 +1,19 @@
+using TeslaSolarCharger.Server.Services.Contracts;
+
+namespace TeslaSolarCharger.Server.Services;
+
+public class CarDataProviderOrchestrator(
+    ILogger<CarDataProviderOrchestrator> logger,
+    IEnumerable<ICarDataProvider> carDataProviders)
+    : ICarDataProviderOrchestrator
+{
+    public async Task RefreshAllCarData()
+    {
+        logger.LogTrace("{method}()", nameof(RefreshAllCarData));
+        foreach (var provider in carDataProviders)
+        {
+            logger.LogDebug("Refreshing car data using {providerType} for {carType}", provider.GetType().Name, provider.SupportedCarType);
+            await provider.RefreshCarData().ConfigureAwait(false);
+        }
+    }
+}

--- a/TeslaSolarCharger/Server/Services/Contracts/ICarDataProvider.cs
+++ b/TeslaSolarCharger/Server/Services/Contracts/ICarDataProvider.cs
@@ -1,0 +1,9 @@
+using TeslaSolarCharger.Shared.Enums;
+
+namespace TeslaSolarCharger.Server.Services.Contracts;
+
+public interface ICarDataProvider
+{
+    CarType SupportedCarType { get; }
+    Task RefreshCarData();
+}

--- a/TeslaSolarCharger/Server/Services/Contracts/ICarDataProviderOrchestrator.cs
+++ b/TeslaSolarCharger/Server/Services/Contracts/ICarDataProviderOrchestrator.cs
@@ -1,0 +1,6 @@
+namespace TeslaSolarCharger.Server.Services.Contracts;
+
+public interface ICarDataProviderOrchestrator
+{
+    Task RefreshAllCarData();
+}

--- a/TeslaSolarCharger/Server/Services/TeslaCarDataProvider.cs
+++ b/TeslaSolarCharger/Server/Services/TeslaCarDataProvider.cs
@@ -1,0 +1,18 @@
+using TeslaSolarCharger.Server.Services.Contracts;
+using TeslaSolarCharger.Shared.Enums;
+
+namespace TeslaSolarCharger.Server.Services;
+
+public class TeslaCarDataProvider(
+    ILogger<TeslaCarDataProvider> logger,
+    ITeslaFleetApiService teslaFleetApiService)
+    : ICarDataProvider
+{
+    public CarType SupportedCarType => CarType.Tesla;
+
+    public async Task RefreshCarData()
+    {
+        logger.LogTrace("{method}()", nameof(RefreshCarData));
+        await teslaFleetApiService.RefreshCarData().ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Summary
Refactored the vehicle data refresh mechanism to use an orchestrator pattern with pluggable car data providers, enabling support for multiple car types beyond Tesla.

## Key Changes
- **New Orchestrator Pattern**: Created `ICarDataProviderOrchestrator` and `CarDataProviderOrchestrator` to manage multiple car data providers and coordinate data refresh operations
- **Provider Interface**: Introduced `ICarDataProvider` interface to define a contract for car-specific data refresh implementations
- **Tesla Provider**: Implemented `TeslaCarDataProvider` as the first concrete provider, delegating to the existing `ITeslaFleetApiService`
- **Job Refactoring**: Updated `VehicleDataRefreshJob` to use the orchestrator instead of directly calling `ITeslaFleetApiService`
- **Dependency Registration**: Registered new services in `ServiceCollectionExtensions` for dependency injection

## Implementation Details
- The orchestrator iterates through all registered `ICarDataProvider` implementations and calls `RefreshCarData()` on each
- Each provider declares its `SupportedCarType` to identify which vehicle types it handles
- The pattern allows future car types (e.g., Hyundai, BMW) to be added by implementing `ICarDataProvider` without modifying existing code
- Comprehensive logging at trace and debug levels for monitoring refresh operations

https://claude.ai/code/session_01NcdKrUnKXYNNYW52aFs5jy