### PR TITLE
Prevent SignalR reconnection alert flickering

### DIFF
--- a/TeslaSolarCharger/Client/Components/StartPage/SignalRConnectionStateComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/SignalRConnectionStateComponent.razor
@@ -87,7 +87,7 @@
             }
 
             // Wait the remaining time for the hint
-            await Task.Delay(HintDelayMilliseconds - AlertDelayMilliseconds, token);
+            await Task.Delay(Math.Max(0, HintDelayMilliseconds - AlertDelayMilliseconds), token);
 
             if (!token.IsCancellationRequested)
             {


### PR DESCRIPTION
This change addresses the user request to prevent the SignalR reconnection alert from flickering briefly on page load or resume. By introducing a 1-second delay, the alert is suppressed for short disconnects that resolve quickly, while still notifying the user of persistent connection issues. The troubleshooting hint retains its original 5-second delay.

---
*PR created automatically by Jules for task [8222246593124995832](https://jules.google.com/task/8222246593124995832) started by @pkuehnel*