### PR TITLE
feat: Add animated success message on SignalR reconnection

### DIFF
--- a/TeslaSolarCharger/Client/Components/StartPage/SignalRConnectionStateComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/SignalRConnectionStateComponent.razor
@@ -29,14 +29,31 @@
         </MudAlert>
     </div>
 }
+else if (SignalRStateService.IsConnected && _showSuccess)
+{
+    <div class="my-2">
+        <MudAlert Severity="Severity.Success" ContentAlignment="HorizontalAlignment.Left" Class="d-flex align-center" NoIcon="true">
+            <div class="d-flex align-center">
+                <div class="mr-3">
+                    <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Small" Class="zoom-in" />
+                </div>
+                <div>
+                    <MudText Typo="Typo.body1">@T(TranslationKeys.SignalRConnected)</MudText>
+                </div>
+            </div>
+        </MudAlert>
+    </div>
+}
 
 @code {
     private const int HintDelayMilliseconds = 5000;
     private const int AlertDelayMilliseconds = 1000;
+    private const int SuccessMessageDurationMilliseconds = 3000;
 
     private CancellationTokenSource? _delayCts;
     private bool _showDelayHint;
     private bool _showAlert;
+    private bool _showSuccess;
 
     protected override void OnInitialized()
     {
@@ -52,6 +69,13 @@
 
     private void UpdateVisibilityState()
     {
+        // Check if we are transitioning from a disconnected state with an alert shown to a connected state
+        if (SignalRStateService.IsConnected && _showAlert)
+        {
+            _showSuccess = true;
+            _ = HideSuccessAfterDelay();
+        }
+
         CancelAndDisposeDelayToken();
 
         _showDelayHint = false;
@@ -108,6 +132,16 @@
         {
             Logger.LogError(ex, "Error in ShowAlertAndHintAfterDelay");
         }
+    }
+
+    private async Task HideSuccessAfterDelay()
+    {
+        await Task.Delay(SuccessMessageDurationMilliseconds);
+        await InvokeAsync(() =>
+        {
+            _showSuccess = false;
+            StateHasChanged();
+        });
     }
 
     private string T(string key) =>

--- a/TeslaSolarCharger/Client/Components/StartPage/SignalRConnectionStateComponent.razor.css
+++ b/TeslaSolarCharger/Client/Components/StartPage/SignalRConnectionStateComponent.razor.css
@@ -1,0 +1,14 @@
+.zoom-in {
+    animation: zoom-in-animation 0.5s ease;
+}
+
+@keyframes zoom-in-animation {
+    0% {
+        transform: scale(0);
+        opacity: 0;
+    }
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}

--- a/TeslaSolarCharger/Shared/Localization/Registries/Pages/HomePageLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Pages/HomePageLocalizationRegistry.cs
@@ -41,5 +41,9 @@ public class HomePageLocalizationRegistry : TextLocalizationRegistry<HomePageLoc
         Register(TranslationKeys.SignalRReconnectionDelayHint,
             new TextLocalizationTranslation(LanguageCodes.English, "Possible causes: poor WiFi connection, or device is outside of home network and cannot reconnect."),
             new TextLocalizationTranslation(LanguageCodes.German, "Mögliche Ursachen: schwache WLAN-Verbindung oder das Gerät befindet sich außerhalb des Heimnetzwerks und kann keine Verbindung herstellen."));
+
+        Register(TranslationKeys.SignalRConnected,
+            new TextLocalizationTranslation(LanguageCodes.English, "Connection established."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Verbindung wiederhergestellt."));
     }
 }

--- a/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
+++ b/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
@@ -186,6 +186,7 @@ public static class TranslationKeys
     public static string HomePagePaypalAltText => nameof(HomePagePaypalAltText);
     public static string SignalRReconnecting => nameof(SignalRReconnecting);
     public static string SignalRReconnectionDelayHint => nameof(SignalRReconnectionDelayHint);
+    public static string SignalRConnected => nameof(SignalRConnected);
 
     public static string CarSettingsTitle => nameof(CarSettingsTitle);
     public static string CarSettingsCreateTokenTitle => nameof(CarSettingsCreateTokenTitle);


### PR DESCRIPTION
This PR implements a user request to show an animated success message when the SignalR connection is re-established after a disconnection.

Changes:
- **UI**: Added a green checkmark icon with a "zoom-in" animation and a localized "Connection established" message.
- **Logic**: The success message only appears if the user was previously alerted about a disconnection. It automatically disappears after 3 seconds.
- **Localization**: Added English and German translations for "Connection established".
- **Verification**: Verified using a custom Playwright script simulating network offline/online events.

---
*PR created automatically by Jules for task [8935126807113745220](https://jules.google.com/task/8935126807113745220) started by @pkuehnel*