### PR TITLE
Fix SignalR success message lifecycle with CancellationToken

### DIFF
--- a/TeslaSolarCharger/Client/Components/StartPage/SignalRConnectionStateComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/SignalRConnectionStateComponent.razor
@@ -51,6 +51,7 @@ else if (SignalRStateService.IsConnected && _showSuccess)
     private const int SuccessMessageDurationMilliseconds = 3000;
 
     private CancellationTokenSource? _delayCts;
+    private CancellationTokenSource? _successCts;
     private bool _showDelayHint;
     private bool _showAlert;
     private bool _showSuccess;
@@ -72,8 +73,10 @@ else if (SignalRStateService.IsConnected && _showSuccess)
         // Check if we are transitioning from a disconnected state with an alert shown to a connected state
         if (SignalRStateService.IsConnected && _showAlert)
         {
+            CancelAndDisposeSuccessToken();
+            _successCts = new CancellationTokenSource();
             _showSuccess = true;
-            _ = HideSuccessAfterDelay();
+            _ = HideSuccessAfterDelay(_successCts.Token);
         }
 
         CancelAndDisposeDelayToken();
@@ -83,6 +86,9 @@ else if (SignalRStateService.IsConnected && _showSuccess)
 
         if (!SignalRStateService.IsConnected)
         {
+            CancelAndDisposeSuccessToken();
+            _showSuccess = false;
+
             _delayCts = new CancellationTokenSource();
             var token = _delayCts.Token; // Capture the token locally
         
@@ -97,6 +103,16 @@ else if (SignalRStateService.IsConnected && _showSuccess)
             _delayCts.Cancel();
             _delayCts.Dispose();
             _delayCts = null;
+        }
+    }
+
+    private void CancelAndDisposeSuccessToken()
+    {
+        if (_successCts != null)
+        {
+            _successCts.Cancel();
+            _successCts.Dispose();
+            _successCts = null;
         }
     }
 
@@ -134,14 +150,25 @@ else if (SignalRStateService.IsConnected && _showSuccess)
         }
     }
 
-    private async Task HideSuccessAfterDelay()
+    private async Task HideSuccessAfterDelay(CancellationToken token)
     {
-        await Task.Delay(SuccessMessageDurationMilliseconds);
-        await InvokeAsync(() =>
+        try
         {
-            _showSuccess = false;
-            StateHasChanged();
-        });
+            await Task.Delay(SuccessMessageDurationMilliseconds, token);
+            if (!token.IsCancellationRequested)
+            {
+                await InvokeAsync(() =>
+                {
+                    _showSuccess = false;
+                    StateHasChanged();
+                });
+            }
+        }
+        catch (OperationCanceledException) { /* Normal */ }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error in HideSuccessAfterDelay");
+        }
     }
 
     private string T(string key) =>
@@ -152,5 +179,6 @@ else if (SignalRStateService.IsConnected && _showSuccess)
     {
         SignalRStateService.OnConnectionStateChanged -= HandleConnectionStateChanged;
         CancelAndDisposeDelayToken();
+        CancelAndDisposeSuccessToken();
     }
 }


### PR DESCRIPTION
This change fixes a potential race condition and `ObjectDisposedException` in the `SignalRConnectionStateComponent`. 

Previously, `HideSuccessAfterDelay` was a fire-and-forget task. If the component was disposed or the connection state changed rapidly while the delay was active, it could try to update the UI state on a disposed component or show stale information.

I have:
1.  Introduced a dedicated `CancellationTokenSource` (`_successCts`) for the success message delay.
2.  Refactored `HideSuccessAfterDelay` to accept a `CancellationToken` and respect cancellation.
3.  Updated `UpdateVisibilityState` to cancel the previous success task before starting a new one, and to cancel it if the connection is lost.
4.  Ensured the token is cancelled and disposed in the component's `Dispose` method.

Verified by building the client and running the full test suite.

---
*PR created automatically by Jules for task [7172823269283170227](https://jules.google.com/task/7172823269283170227) started by @pkuehnel*