### PR TITLE
Fix: Handle parameter changes in LoadpointComponent SignalR subscriptions

### DIFF
--- a/TeslaSolarCharger/Client/Components/StartPage/LoadpointComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/LoadpointComponent.razor
@@ -62,44 +62,52 @@
     public DtoLoadPointOverview LoadPoint { get; set; } = default!;
 
     private IDisposable? _subscription;
+    private string? _lastSubscribedKey;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
-        await base.OnInitializedAsync();
+        await base.OnParametersSetAsync();
         var entityKey = EntityKeyGenerationHelper.GetLoadPointEntityKey(LoadPoint.CarId, LoadPoint.ChargingConnectorId);
-        Logger.LogTrace("Generated entity key: {entityKey}", entityKey);
 
-        // Subscribe to updates
-        _subscription = await SignalRStateService.Subscribe<DtoLoadPointWithCurrentChargingValues>(
-            DataTypeConstants.LoadPointOverviewValues,
-            async void (loadpointValues) =>
-            {
-                try
-                {
-                    Logger.LogTrace("Received new LoadpointOverviewValues: {@values})", loadpointValues);
-                    LoadPoint.ChargingPower = loadpointValues.ChargingPower;
-                    LoadPoint.ActualCurrent = loadpointValues.ChargingCurrent;
-                    LoadPoint.ActualPhases = loadpointValues.ChargingPhases;
-                    await InvokeAsync(StateHasChanged).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    Logger.LogError(e, "Failed to update loadpoint values");
-                }
-            },
-            entityKey
-        );
-
-        // Get initial state
-        var initialValues = await SignalRStateService.GetStateAsync<DtoLoadPointWithCurrentChargingValues>(
-            DataTypeConstants.LoadPointOverviewValues,
-            entityKey);
-
-        if (initialValues != null)
+        if (entityKey != _lastSubscribedKey)
         {
-            LoadPoint.ChargingPower = initialValues.ChargingPower;
-            LoadPoint.ActualCurrent = initialValues.ChargingCurrent;
-            LoadPoint.ActualPhases = initialValues.ChargingPhases;
+            _subscription?.Dispose();
+            _lastSubscribedKey = entityKey;
+
+            Logger.LogTrace("Generated entity key: {entityKey}", entityKey);
+
+            // Subscribe to updates
+            _subscription = await SignalRStateService.Subscribe<DtoLoadPointWithCurrentChargingValues>(
+                DataTypeConstants.LoadPointOverviewValues,
+                async void (loadpointValues) =>
+                {
+                    try
+                    {
+                        Logger.LogTrace("Received new LoadpointOverviewValues: {@values})", loadpointValues);
+                        LoadPoint.ChargingPower = loadpointValues.ChargingPower;
+                        LoadPoint.ActualCurrent = loadpointValues.ChargingCurrent;
+                        LoadPoint.ActualPhases = loadpointValues.ChargingPhases;
+                        await InvokeAsync(StateHasChanged).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.LogError(e, "Failed to update loadpoint values");
+                    }
+                },
+                entityKey
+            );
+
+            // Get initial state
+            var initialValues = await SignalRStateService.GetStateAsync<DtoLoadPointWithCurrentChargingValues>(
+                DataTypeConstants.LoadPointOverviewValues,
+                entityKey);
+
+            if (initialValues != null)
+            {
+                LoadPoint.ChargingPower = initialValues.ChargingPower;
+                LoadPoint.ActualCurrent = initialValues.ChargingCurrent;
+                LoadPoint.ActualPhases = initialValues.ChargingPhases;
+            }
         }
     }
 


### PR DESCRIPTION
- Changed `LoadpointComponent.razor` lifecycle from `OnInitializedAsync` to `OnParametersSetAsync`.
- Added `_lastSubscribedKey` tracking variable to detect parameter changes.
- Ensure previous `_subscription` is disposed before re-subscribing.
- This correctly aligns the SignalR entity key with Blazor's parameter updates when the component instance is recycled.

---
*PR created automatically by Jules for task [8357064537335588501](https://jules.google.com/task/8357064537335588501) started by @pkuehnel*