### PR TITLE
Feature: Dynamic Battery Icon Color for Power Flow

### DIFF
--- a/TeslaSolarCharger/Client/Components/BatteryIcon.razor
+++ b/TeslaSolarCharger/Client/Components/BatteryIcon.razor
@@ -24,6 +24,9 @@
     [Parameter]
     public int? StateOfCharge { get; set; }
 
+    [Parameter]
+    public string? Color { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
@@ -40,6 +43,11 @@
 
     private string GetBatteryColor(int soc)
     {
+        if (Color != null)
+        {
+            return Color;
+        }
+
         if (soc > 50) return AppColors.BatterySocGoodColor;
         if (soc > 25) return AppColors.BatterySocWarningColor;
         return AppColors.BatterySocCriticalColor;

--- a/TeslaSolarCharger/Client/Components/StartPage/PowerFlowComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/PowerFlowComponent.razor
@@ -5,6 +5,8 @@
 @using TeslaSolarCharger.Shared.Localization.Contracts
 @using TeslaSolarCharger.Shared.Localization.Registries
 @using TeslaSolarCharger.Shared.SignalRClients
+@using TeslaSolarCharger.Shared.Dtos.BaseConfiguration
+@using TeslaSolarCharger.Client.Helper.Contracts
 @implements IDisposable
 
 @inject IConstants Constants
@@ -13,6 +15,7 @@
 @inject ITextLocalizationService TextLocalizer
 @inject ILogger<PowerFlowComponent> Logger
 @inject IThemeStateService ThemeStateService
+@inject IHttpClientHelper HttpClientHelper
 
 @if (_pvValues == default)
 {
@@ -152,7 +155,7 @@ else
             {
                 <foreignObject x="@(BatteryLocation.X - CircleContentLocationDifference)" y="@(BatteryLocation.Y - CircleContentLocationDifference + 10)" width="70" height="80">
                     <div style="text-align: center;">
-                        <BatteryIcon StateOfCharge="@_pvValues.HomeBatterySoc" />
+                        <BatteryIcon StateOfCharge="@_pvValues.HomeBatterySoc" Color="@BatteryColor" />
                         <div>@Math.Abs(_pvValues.HomeBatteryPower ?? 0).ToString("N0") @T(TranslationKeys.UnitWatts)</div>
                     </div>
                 </foreignObject>
@@ -185,6 +188,7 @@ else
     private List<Ball> Balls { get; set; } = new();
 
     private DtoPvValues? _pvValues;
+    private DtoDynamicMinSocSettings? _dynamicMinSocSettings;
     private readonly int _widthInPixel = 420;
 
 
@@ -193,11 +197,29 @@ else
 
 
     private IDisposable? _subscription;
+    private IDisposable? _dynamicMinSocSubscription;
 
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
         ThemeStateService.OnDarkModeChanged += OnDarkModeChangedHandler;
+
+        await RefreshDynamicMinSocSettings();
+
+        _dynamicMinSocSubscription = await SignalRStateService.SubscribeToTrigger(
+            DataTypeConstants.DynamicHomeBatteryMinSocChanged,
+            async void () =>
+            {
+                try
+                {
+                    await RefreshDynamicMinSocSettings();
+                    await InvokeAsync(StateHasChanged);
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError(e, "Could not refresh dynamic min soc settings");
+                }
+            });
 
         // Subscribe to PV value changes
         _subscription = await SignalRStateService.Subscribe<DtoPvValues>(
@@ -645,6 +667,32 @@ else
         return homePower;
     }
 
+
+    private string? BatteryColor
+    {
+        get
+        {
+            if (_pvValues?.HomeBatterySoc == null) return null;
+            if (_dynamicMinSocSettings?.DynamicHomeBatteryMinSoc != true) return null;
+
+            var soc = _pvValues.HomeBatterySoc.Value;
+            var minSoc = _dynamicMinSocSettings.HomeBatteryMinSoc ?? 0;
+            var dynamicMinSoc = _dynamicMinSocSettings.HomeBatteryMinDynamicMinSoc ?? 5;
+
+            if (minSoc == dynamicMinSoc) return AppColors.BatterySocGoodColor;
+
+            if (soc < minSoc - 15) return AppColors.BatterySocCriticalColor;
+            if (soc > minSoc + 15) return AppColors.BatterySocGoodColor;
+
+            return AppColors.BatterySocWarningColor;
+        }
+    }
+
+    private async Task RefreshDynamicMinSocSettings()
+    {
+        _dynamicMinSocSettings = await HttpClientHelper.SendGetRequestWithSnackbarAsync<DtoDynamicMinSocSettings>("/api/BaseConfiguration/GetDynamicMinSocSettings");
+    }
+
     private string T(string key) =>
         TextLocalizer.Get<SharedComponentLocalizationRegistry>(key, typeof(SharedComponentLocalizationRegistry))
         ?? key;
@@ -652,6 +700,7 @@ else
     public void Dispose()
     {
         _subscription?.Dispose();
+        _dynamicMinSocSubscription?.Dispose();
         ThemeStateService.OnDarkModeChanged -= OnDarkModeChangedHandler;
     }
 }

--- a/TeslaSolarCharger/Server/Contracts/IBaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Contracts/IBaseConfigurationService.cs
@@ -15,4 +15,5 @@ public interface IBaseConfigurationService
     Task<(Stream stream, string fileName)> DownloadBackupStream(string? backupZipDestinationDirectory);
     void ProcessPendingRestore();
     bool HomeBatteryValuesAvailable();
+    DtoDynamicMinSocSettings GetDynamicMinSocSettings();
 }

--- a/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
+++ b/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
@@ -16,12 +16,11 @@ namespace TeslaSolarCharger.Server.Controllers
         public Task<DtoBaseConfiguration> GetBaseConfiguration() => configurationWrapper.GetBaseConfigurationAsync();
 
         [HttpGet]
-        public DtoDynamicMinSocSettings GetDynamicMinSocSettings() => new DtoDynamicMinSocSettings
+        public DtoDynamicMinSocSettings GetDynamicMinSocSettings()
         {
-            DynamicHomeBatteryMinSoc = configurationWrapper.DynamicHomeBatteryMinSoc(),
-            HomeBatteryMinSoc = configurationWrapper.HomeBatteryMinSoc(),
-            HomeBatteryMinDynamicMinSoc = configurationWrapper.HomeBatteryMinDynamicMinSoc()
-        };
+            var result = service.GetDynamicMinSocSettings();
+            return result;
+        }
 
         [HttpGet]
         public DtoValue<bool> AllowPowerBufferChangeOnHome() => new(configurationWrapper.AllowPowerBufferChangeOnHome());

--- a/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
+++ b/TeslaSolarCharger/Server/Controllers/BaseConfigurationController.cs
@@ -16,6 +16,14 @@ namespace TeslaSolarCharger.Server.Controllers
         public Task<DtoBaseConfiguration> GetBaseConfiguration() => configurationWrapper.GetBaseConfigurationAsync();
 
         [HttpGet]
+        public DtoDynamicMinSocSettings GetDynamicMinSocSettings() => new DtoDynamicMinSocSettings
+        {
+            DynamicHomeBatteryMinSoc = configurationWrapper.DynamicHomeBatteryMinSoc(),
+            HomeBatteryMinSoc = configurationWrapper.HomeBatteryMinSoc(),
+            HomeBatteryMinDynamicMinSoc = configurationWrapper.HomeBatteryMinDynamicMinSoc()
+        };
+
+        [HttpGet]
         public DtoValue<bool> AllowPowerBufferChangeOnHome() => new(configurationWrapper.AllowPowerBufferChangeOnHome());
 
         [HttpGet]

--- a/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
@@ -257,6 +257,17 @@ public class BaseConfigurationService(
         return settings.HomeBatteryPower != default && settings.HomeBatterySoc != default;
     }
 
+    public DtoDynamicMinSocSettings GetDynamicMinSocSettings()
+    {
+        var minSocSettings = new DtoDynamicMinSocSettings
+        {
+            DynamicHomeBatteryMinSoc = configurationWrapper.DynamicHomeBatteryMinSoc(),
+            HomeBatteryMinSoc = configurationWrapper.HomeBatteryMinSoc(),
+            HomeBatteryMinDynamicMinSoc = configurationWrapper.HomeBatteryMinDynamicMinSoc(),
+        };
+        return minSocSettings;
+    }
+
     public List<DtoBackupFileInformation> GetAutoBackupFileInformations()
     {
         var backupZipDirectory = configurationWrapper.AutoBackupsZipDirectory();

--- a/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
@@ -108,7 +108,7 @@ public class BaseConfigurationService(
             Directory.CreateDirectory(backupZipDirectory);
             var destinationArchiveFileName = Path.Combine(backupZipDirectory, backupFileName);
             logger.LogTrace("Creating backup zip file: {destinationArchiveFileName}", destinationArchiveFileName);
-            ZipFile.CreateFromDirectory(backupCopyDestinationDirectory, destinationArchiveFileName);
+            await ZipFile.CreateFromDirectoryAsync(backupCopyDestinationDirectory, destinationArchiveFileName);
             logger.LogTrace("Backup zip file created successfully: {destinationArchiveFileName}", destinationArchiveFileName);
             return destinationArchiveFileName;
         }
@@ -123,12 +123,6 @@ public class BaseConfigurationService(
             {
                 await jobManager.StartJobs().ConfigureAwait(false);
             }
-        var changes = new StateUpdateDto()
-        {
-            DataType = DataTypeConstants.DynamicHomeBatteryMinSocChanged,
-            Timestamp = dateTimeProvider.DateTimeOffSetUtcNow(),
-        };
-        await appStateNotifier.NotifyStateUpdateAsync(changes).ConfigureAwait(false);
         }
     }
 

--- a/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/BaseConfigurationService.cs
@@ -8,6 +8,8 @@ using TeslaSolarCharger.Shared.Dtos;
 using TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
 using TeslaSolarCharger.Shared.Dtos.Contracts;
 using TeslaSolarCharger.Shared.Resources.Contracts;
+using TeslaSolarCharger.Server.SignalR.Notifiers.Contracts;
+using TeslaSolarCharger.Shared.SignalRClients;
 
 namespace TeslaSolarCharger.Server.Services;
 
@@ -19,7 +21,8 @@ public class BaseConfigurationService(
     ISettings settings,
     IDbConnectionStringHelper dbConnectionStringHelper,
     IConstants constants,
-    IDateTimeProvider dateTimeProvider)
+    IDateTimeProvider dateTimeProvider,
+    IAppStateNotifier appStateNotifier)
     : IBaseConfigurationService
 {
     public async Task UpdateBaseConfigurationAsync(DtoBaseConfiguration baseConfiguration)
@@ -37,6 +40,12 @@ public class BaseConfigurationService(
         {
             await jobManager.StartJobs().ConfigureAwait(false);
         }
+        var changes = new StateUpdateDto()
+        {
+            DataType = DataTypeConstants.DynamicHomeBatteryMinSocChanged,
+            Timestamp = dateTimeProvider.DateTimeOffSetUtcNow(),
+        };
+        await appStateNotifier.NotifyStateUpdateAsync(changes).ConfigureAwait(false);
     }
 
     public async Task UpdateMaxCombinedCurrent(int? maxCombinedCurrent)
@@ -114,6 +123,12 @@ public class BaseConfigurationService(
             {
                 await jobManager.StartJobs().ConfigureAwait(false);
             }
+        var changes = new StateUpdateDto()
+        {
+            DataType = DataTypeConstants.DynamicHomeBatteryMinSocChanged,
+            Timestamp = dateTimeProvider.DateTimeOffSetUtcNow(),
+        };
+        await appStateNotifier.NotifyStateUpdateAsync(changes).ConfigureAwait(false);
         }
     }
 

--- a/TeslaSolarCharger/Server/Services/HomeBatteryEnergyCalculator.cs
+++ b/TeslaSolarCharger/Server/Services/HomeBatteryEnergyCalculator.cs
@@ -1,10 +1,14 @@
 using TeslaSolarCharger.Server.Services.Contracts;
+using TeslaSolarCharger.Server.SignalR.Notifiers;
+using TeslaSolarCharger.Server.SignalR.Notifiers.Contracts;
 using TeslaSolarCharger.Shared;
 using TeslaSolarCharger.Shared.Contracts;
 using TeslaSolarCharger.Shared.Dtos;
 using TeslaSolarCharger.Shared.Dtos.Contracts;
 using TeslaSolarCharger.Shared.Dtos.Settings;
 using TeslaSolarCharger.Shared.Resources.Contracts;
+using TeslaSolarCharger.Shared.SignalRClients;
+using TeslaSolarCharger.Shared.TimeProviding;
 
 namespace TeslaSolarCharger.Server.Services;
 
@@ -17,6 +21,7 @@ public class HomeBatteryEnergyCalculator : IHomeBatteryEnergyCalculator
     private readonly ISunCalculator _sunCalculator;
     private readonly IEnergyDataService _energyDataService;
     private readonly IConstants _constants;
+    private readonly IAppStateNotifier _appStateNotifier;
 
     public HomeBatteryEnergyCalculator(ILogger<HomeBatteryEnergyCalculator> logger,
         IConfigurationWrapper configurationWrapper,
@@ -24,7 +29,8 @@ public class HomeBatteryEnergyCalculator : IHomeBatteryEnergyCalculator
         ISettings settings,
         ISunCalculator sunCalculator,
         IEnergyDataService energyDataService,
-        IConstants constants)
+        IConstants constants,
+        IAppStateNotifier appStateNotifier)
     {
         _logger = logger;
         _configurationWrapper = configurationWrapper;
@@ -33,6 +39,7 @@ public class HomeBatteryEnergyCalculator : IHomeBatteryEnergyCalculator
         _sunCalculator = sunCalculator;
         _energyDataService = energyDataService;
         _constants = constants;
+        _appStateNotifier = appStateNotifier;
     }
 
     public async Task RefreshHomeBatteryMinSoc(CancellationToken cancellationToken)
@@ -75,6 +82,12 @@ public class HomeBatteryEnergyCalculator : IHomeBatteryEnergyCalculator
             var configuration = await _configurationWrapper.GetBaseConfigurationAsync();
             configuration.HomeBatteryMinSoc = calculateMinSoc;
             await _configurationWrapper.UpdateBaseConfigurationAsync(configuration);
+            var changes = new StateUpdateDto()
+            {
+                DataType = DataTypeConstants.DynamicHomeBatteryMinSocChanged,
+                Timestamp = _dateTimeProvider.DateTimeOffSetUtcNow(),
+            };
+            await _appStateNotifier.NotifyStateUpdateAsync(changes).ConfigureAwait(false);
         }
     }
 

--- a/TeslaSolarCharger/Shared/Dtos/BaseConfiguration/DtoDynamicMinSocSettings.cs
+++ b/TeslaSolarCharger/Shared/Dtos/BaseConfiguration/DtoDynamicMinSocSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace TeslaSolarCharger.Shared.Dtos.BaseConfiguration;
+
+public class DtoDynamicMinSocSettings
+{
+    public bool? DynamicHomeBatteryMinSoc { get; set; }
+    public int? HomeBatteryMinSoc { get; set; }
+    public int? HomeBatteryMinDynamicMinSoc { get; set; }
+}

--- a/TeslaSolarCharger/Shared/SignalRClients/DataTypeConstants.cs
+++ b/TeslaSolarCharger/Shared/SignalRClients/DataTypeConstants.cs
@@ -11,4 +11,5 @@ public class DataTypeConstants
     public const string NotChargingAsExpectedChangeTrigger = "NotChargingAsExpectedChangeTrigger";
     public const string ChargingSchedulesChangeTrigger = "ChargingSchedulesChangeTrigger";
     public const string EnergyPredictionChangeTrigger = "EnergyPredictionChangeTrigger";
+    public const string DynamicHomeBatteryMinSocChanged = "DynamicHomeBatteryMinSocChanged";
 }


### PR DESCRIPTION
Implements dynamic color coding for the home battery icon in the `PowerFlowComponent` based on the user's dynamic minimum State of Charge (SoC) configuration. Instead of fixed thresholds, the battery icon now indicates its status relative to the target min SoC: "Good" when equal to the default, "Warning" when within +/- 15%, "Critical" if >15% below, and "Good" if >15% above. Updates occur in real-time via SignalR.

---
*PR created automatically by Jules for task [11336065258809806821](https://jules.google.com/task/11336065258809806821) started by @pkuehnel*