### PR TITLE
Fix systematic truncation bias in energy calculations

### DIFF
--- a/TeslaSolarCharger/Server/Services/EnergyDataService.cs
+++ b/TeslaSolarCharger/Server/Services/EnergyDataService.cs
@@ -344,7 +344,7 @@ public class EnergyDataService(ILogger<EnergyDataService> logger,
 
             if (nextMeterValue != default && meterValue != default)
             {
-                var energyDifference = Convert.ToInt32((nextMeterValue.EstimatedEnergyWs - meterValue.EstimatedEnergyWs) / 3600);
+                var energyDifference = Convert.ToInt32((nextMeterValue.EstimatedEnergyWs - meterValue.EstimatedEnergyWs) / 3600.0);
                 createdWh.Add(slicedTimeStamp, energyDifference);
             }
         }
@@ -441,7 +441,7 @@ public class EnergyDataService(ILogger<EnergyDataService> logger,
             var weightedSamples = kvp.Value;
             var weightedSum = weightedSamples.Sum(item => item.meterValueChange * item.weight);
             var weightTotal = weightedSamples.Sum(item => item.weight);
-            avgHourlyWeightedFactors[timeSpan] = (int)(weightedSum / weightTotal);
+            avgHourlyWeightedFactors[timeSpan] = Convert.ToInt32(weightedSum / weightTotal);
         }
 
         return avgHourlyWeightedFactors;
@@ -465,7 +465,7 @@ public class EnergyDataService(ILogger<EnergyDataService> logger,
                 continue;
             }
             var predictedWh = radiationValue * factor;
-            predictedProduction[resultTimeStamp] = (int)predictedWh;
+            predictedProduction[resultTimeStamp] = Convert.ToInt32(predictedWh);
         }
         return predictedProduction;
     }


### PR DESCRIPTION
Fix systematic truncation bias in energy calculations

When converting energy values from Watt-seconds to Watt-hours (by dividing by 3600), integer division previously caused truncation toward zero. This resulted in an accumulated loss of precision and an underestimation of historic actual energy generation, which artificially widened the gap between estimated and actual solar production. This patch fixes the calculations to use floating-point division and proper rounding (Convert.ToInt32), ensuring precision is preserved and actual production values are reported correctly.

---
*PR created automatically by Jules for task [12971110360911157062](https://jules.google.com/task/12971110360911157062) started by @pkuehnel*