### PR TITLE
feat(TeslaFleetApiService): rate limited Fleet API fallback for BLE cars without car license

### DIFF
--- a/TeslaSolarCharger.Tests/Services/Server/FleetApiRateLimitServiceTests.cs
+++ b/TeslaSolarCharger.Tests/Services/Server/FleetApiRateLimitServiceTests.cs
@@ -100,6 +100,51 @@ public class FleetApiRateLimitServiceTests
         Assert.Equal(UtcAt(BaseTime.AddMinutes(61)).AddMinutes(60), CreateService(BaseTime.AddMinutes(70)).GetNextAllowedUtc(car));
     }
 
+    [Theory]
+    [InlineData(10)]
+    [InlineData(59)]
+    public void CommandAfterGraceWindowButWithinCommandWindowDoesNotMoveTheSlot(int minutesAfterCountedCommand)
+    {
+        var car = new DtoCar();
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        //Such a command can only happen when the local limit was bypassed, e.g. by a manual Fleet API test. The backend anchors
+        //its window the same way (see TeslaCommandRateLimitService.EnsureCommandAllowed), so moving the slot here would block
+        //locally until one hour after this command while the backend already allows one hour after the first command.
+        CreateService(BaseTime.AddMinutes(minutesAfterCountedCommand)).RecordSuccessfulCommand(car);
+        Assert.Equal(UtcAt(BaseTime), car.LastCountedFleetApiCommand);
+        Assert.Null(CreateService(BaseTime.AddMinutes(60)).GetNextAllowedUtc(car));
+    }
+
+    [Fact]
+    public void RateLimitedByBackendBlocksCommandsWithoutKnownLocalSlot()
+    {
+        var car = new DtoCar();
+        //No locally counted command, e.g. after a restart, but the backend still blocks
+        CreateService(BaseTime).RecordRateLimited(car);
+        Assert.Equal(UtcAt(BaseTime).AddMinutes(55), CreateService(BaseTime.AddMinutes(54)).GetNextAllowedUtc(car));
+        Assert.Null(CreateService(BaseTime.AddMinutes(55)).GetNextAllowedUtc(car));
+    }
+
+    [Fact]
+    public void RateLimitedByBackendDoesNotOpenGraceWindow()
+    {
+        var car = new DtoCar();
+        CreateService(BaseTime).RecordRateLimited(car);
+        Assert.NotNull(CreateService(BaseTime).GetNextAllowedUtc(car));
+        Assert.NotNull(CreateService(BaseTime.AddMinutes(2)).GetNextAllowedUtc(car));
+    }
+
+    [Fact]
+    public void RateLimitedByBackendDoesNotShortenKnownBlock()
+    {
+        var car = new DtoCar();
+        //Backend rejects a command sent within the local grace window, so the local block must stay anchored at the counted command
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        CreateService(BaseTime.AddMinutes(2)).RecordRateLimited(car);
+        Assert.Equal(UtcAt(BaseTime), car.LastCountedFleetApiCommand);
+        Assert.Equal(UtcAt(BaseTime).AddMinutes(60), CreateService(BaseTime.AddMinutes(30)).GetNextAllowedUtc(car));
+    }
+
     [Fact]
     public void WakeUpWithFollowUpCommandsScenario()
     {

--- a/TeslaSolarCharger.Tests/Services/Server/FleetApiRateLimitServiceTests.cs
+++ b/TeslaSolarCharger.Tests/Services/Server/FleetApiRateLimitServiceTests.cs
@@ -1,0 +1,118 @@
+using System;
+using Microsoft.Extensions.Logging.Abstractions;
+using TeslaSolarCharger.Shared.Dtos.Settings;
+using TeslaSolarCharger.Shared.TimeProviding;
+using Xunit;
+
+namespace TeslaSolarCharger.Tests.Services.Server;
+
+public class FleetApiRateLimitServiceTests
+{
+    //Winter date so no DST change can occur within the tested time ranges
+    private static readonly DateTime BaseTime = new(2026, 2, 2, 8, 0, 0);
+
+    private static TeslaSolarCharger.Server.Services.FleetApiRateLimitService CreateService(DateTime currentTime)
+    {
+        return new(NullLogger<TeslaSolarCharger.Server.Services.FleetApiRateLimitService>.Instance, new FakeDateTimeProvider(currentTime));
+    }
+
+    private static DateTime UtcAt(DateTime currentTime)
+    {
+        return new FakeDateTimeProvider(currentTime).UtcNow();
+    }
+
+    [Fact]
+    public void AllowsFirstCommand()
+    {
+        var car = new DtoCar();
+        var service = CreateService(BaseTime);
+        Assert.Null(service.GetNextAllowedUtc(car));
+    }
+
+    [Fact]
+    public void GetNextAllowedUtcDoesNotConsumeBudget()
+    {
+        var car = new DtoCar();
+        var service = CreateService(BaseTime);
+        Assert.Null(service.GetNextAllowedUtc(car));
+        Assert.Null(service.GetNextAllowedUtc(car));
+        Assert.Null(car.LastCountedFleetApiCommand);
+    }
+
+    [Fact]
+    public void RecordedCommandConsumesHourlySlot()
+    {
+        var car = new DtoCar();
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        Assert.Equal(UtcAt(BaseTime), car.LastCountedFleetApiCommand);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    public void AllowsCommandsWithinGraceWindow(int minutesAfterCountedCommand)
+    {
+        var car = new DtoCar();
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        var service = CreateService(BaseTime.AddMinutes(minutesAfterCountedCommand));
+        Assert.Null(service.GetNextAllowedUtc(car));
+    }
+
+    [Fact]
+    public void CommandsWithinGraceWindowDoNotExtendWindow()
+    {
+        var car = new DtoCar();
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        CreateService(BaseTime.AddMinutes(4)).RecordSuccessfulCommand(car);
+        Assert.Equal(UtcAt(BaseTime), car.LastCountedFleetApiCommand);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(30)]
+    [InlineData(59)]
+    public void BlocksCommandsAfterGraceWindowUntilHourIsOver(int minutesAfterCountedCommand)
+    {
+        var car = new DtoCar();
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        var service = CreateService(BaseTime.AddMinutes(minutesAfterCountedCommand));
+        Assert.Equal(UtcAt(BaseTime).AddMinutes(60), service.GetNextAllowedUtc(car));
+    }
+
+    [Fact]
+    public void AllowsCommandAfterOneHour()
+    {
+        var car = new DtoCar();
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        var service = CreateService(BaseTime.AddMinutes(60));
+        Assert.Null(service.GetNextAllowedUtc(car));
+    }
+
+    [Fact]
+    public void CommandAfterOneHourConsumesNewSlot()
+    {
+        var car = new DtoCar();
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        CreateService(BaseTime.AddMinutes(61)).RecordSuccessfulCommand(car);
+        Assert.Equal(UtcAt(BaseTime.AddMinutes(61)), car.LastCountedFleetApiCommand);
+        //The new slot opens its own grace window and blocks again afterwards
+        Assert.Null(CreateService(BaseTime.AddMinutes(63)).GetNextAllowedUtc(car));
+        Assert.Equal(UtcAt(BaseTime.AddMinutes(61)).AddMinutes(60), CreateService(BaseTime.AddMinutes(70)).GetNextAllowedUtc(car));
+    }
+
+    [Fact]
+    public void WakeUpWithFollowUpCommandsScenario()
+    {
+        var car = new DtoCar();
+        //Wake up succeeds and consumes the hourly slot
+        CreateService(BaseTime).RecordSuccessfulCommand(car);
+        //Set charging amps two minutes later is allowed and does not consume the slot
+        Assert.Null(CreateService(BaseTime.AddMinutes(2)).GetNextAllowedUtc(car));
+        CreateService(BaseTime.AddMinutes(2)).RecordSuccessfulCommand(car);
+        //Charge start three minutes later is allowed and does not consume the slot
+        Assert.Null(CreateService(BaseTime.AddMinutes(3)).GetNextAllowedUtc(car));
+        CreateService(BaseTime.AddMinutes(3)).RecordSuccessfulCommand(car);
+        //Ten minutes later the grace window is over, the next command is only allowed one hour after the wake up
+        Assert.Equal(UtcAt(BaseTime).AddMinutes(60), CreateService(BaseTime.AddMinutes(10)).GetNextAllowedUtc(car));
+    }
+}

--- a/TeslaSolarCharger/Server/Resources/PossibleIssues/Contracts/IIssueKeys.cs
+++ b/TeslaSolarCharger/Server/Resources/PossibleIssues/Contracts/IIssueKeys.cs
@@ -20,7 +20,6 @@ public interface IIssueKeys
     string UnsignedCommand { get; }
     string BleCommandNoSuccess { get; }
     string SolarValuesNotAvailable { get; }
-    string UsingFleetApiAsBleFallback { get; }
     string BleVersionCompatibility { get; }
     string NoBackendApiToken { get; }
     string FleetApiTokenExpired { get; }
@@ -28,6 +27,7 @@ public interface IIssueKeys
     string BackendTokenNotRefreshable { get; }
     string BaseAppNotLicensed { get; }
     string FleetApiNotLicensed { get; }
+    string FleetApiCommandRateLimited { get; }
     string FleetTelemetryNotConnected { get; }
     string FleetTelemetryConfigurationError { get; }
     string FleetTelemetryConfigurationDeletionError { get; }

--- a/TeslaSolarCharger/Server/Resources/PossibleIssues/IssueKeys.cs
+++ b/TeslaSolarCharger/Server/Resources/PossibleIssues/IssueKeys.cs
@@ -23,13 +23,13 @@ public class IssueKeys : IIssueKeys
     public string UnsignedCommand => "UnsignedCommand";
     public string BleCommandNoSuccess => "BleCommandNoSuccess_";
     public string SolarValuesNotAvailable => "SolarValuesNotAvailable";
-    public string UsingFleetApiAsBleFallback => "UsingFleetApiAsBleFallback";
     public string BleVersionCompatibility => "BleVersionCompatibility";
     public string NoBackendApiToken => "NoBackendApiToken";
     public string BackendTokenNotRefreshable => "BackendTokenNotRefreshable";
     public string FleetApiTokenExpired => "FleetApiTokenExpired";
     public string BaseAppNotLicensed => "BaseAppNotLicensed";
     public string FleetApiNotLicensed => "FleetApiNotLicensed";
+    public string FleetApiCommandRateLimited => "FleetApiCommandRateLimited";
     public string FleetTelemetryNotConnected => "FleetTelemetryNotConnected";
     public string FleetTelemetryConfigurationError => "FleetTelemetryConfigurationError";
     public string FleetTelemetryConfigurationDeletionError => "FleetTelemetryConfigurationDeletionError";

--- a/TeslaSolarCharger/Server/Resources/PossibleIssues/PossibleIssues.cs
+++ b/TeslaSolarCharger/Server/Resources/PossibleIssues/PossibleIssues.cs
@@ -162,14 +162,6 @@ public class PossibleIssues(IIssueKeys issueKeys) : IPossibleIssues
                 HasPlaceHolderIssueKey = false,
             }
         },
-        { issueKeys.UsingFleetApiAsBleFallback, new DtoIssue
-            {
-                IssueSeverity = IssueSeverity.Warning,
-                IsTelegramEnabled = true,
-                ShowErrorAfterOccurrences = 2,
-                HasPlaceHolderIssueKey = false,
-            }
-        },
         { issueKeys.BleVersionCompatibility, new DtoIssue
             {
                 IssueSeverity = IssueSeverity.Error,
@@ -228,6 +220,15 @@ public class PossibleIssues(IIssueKeys issueKeys) : IPossibleIssues
             {
                 IssueSeverity = IssueSeverity.Error,
                 IsTelegramEnabled = true,
+                ShowErrorAfterOccurrences = 1,
+                HasPlaceHolderIssueKey = false,
+                HideOccurrenceCount = true,
+            }
+        },
+        { issueKeys.FleetApiCommandRateLimited, new DtoIssue
+            {
+                IssueSeverity = IssueSeverity.Warning,
+                IsTelegramEnabled = false,
                 ShowErrorAfterOccurrences = 1,
                 HasPlaceHolderIssueKey = false,
                 HideOccurrenceCount = true,

--- a/TeslaSolarCharger/Server/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Server/ServiceCollectionExtensions.cs
@@ -133,6 +133,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<IIndexService, IndexService>()
             .AddTransient<ISpotPriceService, SpotPriceService>()
             .AddTransient<ITeslaFleetApiService, TeslaFleetApiService>()
+            .AddTransient<IFleetApiRateLimitService, FleetApiRateLimitService>()
             .AddTransient<ITokenHelper, TokenHelper>()
             .AddTransient<ITscConfigurationService, TscConfigurationService>()
             .AddTransient<ISetupCacheService, SetupCacheService>()

--- a/TeslaSolarCharger/Server/Services/Contracts/IFleetApiRateLimitService.cs
+++ b/TeslaSolarCharger/Server/Services/Contracts/IFleetApiRateLimitService.cs
@@ -6,4 +6,5 @@ public interface IFleetApiRateLimitService
 {
     DateTime? GetNextAllowedUtc(DtoCar car);
     void RecordSuccessfulCommand(DtoCar car);
+    void RecordRateLimited(DtoCar car);
 }

--- a/TeslaSolarCharger/Server/Services/Contracts/IFleetApiRateLimitService.cs
+++ b/TeslaSolarCharger/Server/Services/Contracts/IFleetApiRateLimitService.cs
@@ -1,0 +1,9 @@
+using TeslaSolarCharger.Shared.Dtos.Settings;
+
+namespace TeslaSolarCharger.Server.Services.Contracts;
+
+public interface IFleetApiRateLimitService
+{
+    DateTime? GetNextAllowedUtc(DtoCar car);
+    void RecordSuccessfulCommand(DtoCar car);
+}

--- a/TeslaSolarCharger/Server/Services/ErrorDetectionService.cs
+++ b/TeslaSolarCharger/Server/Services/ErrorDetectionService.cs
@@ -21,7 +21,8 @@ public class ErrorDetectionService(ILogger<ErrorDetectionService> logger,
     ITokenHelper tokenHelper,
     IConstants constants,
     IFleetTelemetryWebSocketService fleetTelemetryWebSocketService,
-    IBackendApiService backendApiService) : IErrorDetectionService
+    IBackendApiService backendApiService,
+    IFleetApiRateLimitService fleetApiRateLimitService) : IErrorDetectionService
 {
     public async Task DetectErrors()
     {
@@ -142,6 +143,14 @@ public class ErrorDetectionService(ILogger<ErrorDetectionService> logger,
             else
             {
                 await errorHandlingService.HandleErrorResolved(issueKeys.FleetApiNotLicensed, car.Vin);
+            }
+
+            //Resolved here and not only after a successful Fleet API command, as the rate limit is also irrelevant again when BLE
+            //works again, the car needs no commands at all or a Fleet API license was bought. In all those cases no Fleet API
+            //command is sent that could resolve the issue.
+            if (fleetApiRateLimitService.GetNextAllowedUtc(car) == default)
+            {
+                await errorHandlingService.HandleErrorResolved(issueKeys.FleetApiCommandRateLimited, car.Vin);
             }
 
             if (car.IsOnline.Value == false)

--- a/TeslaSolarCharger/Server/Services/ErrorDetectionService.cs
+++ b/TeslaSolarCharger/Server/Services/ErrorDetectionService.cs
@@ -110,18 +110,6 @@ public class ErrorDetectionService(ILogger<ErrorDetectionService> logger,
 
         foreach (var car in settings.CarsToManage)
         {
-            if ((car.LastNonSuccessBleCall != default)
-                && (car.LastNonSuccessBleCall.Value > (dateTimeProvider.UtcNow() - configurationWrapper.BleUsageStopAfterError())))
-            {
-                //Issue should already be active as is set on TeslaFleetApiService.
-                //Note: The same logic for the if is used in TeslaFleetApiService.SendCommandToTeslaApi<T> if ble is enabled.
-                //So: let it be like that even though the if part is empty.
-            }
-            else
-            {
-                //ToDo: In a future release this should only be done if no fleet api request was sent the last x minutes (BleUsageStopAfterError)
-                await errorHandlingService.HandleErrorResolved(issueKeys.UsingFleetApiAsBleFallback, car.Vin);
-            }
             var carSettings = await context.Cars
                 .Where(c => c.Vin == car.Vin)
                 .Select(c => new

--- a/TeslaSolarCharger/Server/Services/FleetApiRateLimitService.cs
+++ b/TeslaSolarCharger/Server/Services/FleetApiRateLimitService.cs
@@ -47,4 +47,24 @@ public class FleetApiRateLimitService(
             car.LastCountedFleetApiCommand = currentDate;
         }
     }
+
+    /// <summary>
+    /// Blocks further commands after the backend rejected one as rate limited. As <see cref="DtoCar.LastCountedFleetApiCommand"/>
+    /// is only kept in memory but the backend enforces the limit across restarts, the local state can be empty while the backend
+    /// still blocks. Without this every charging cycle would send a command just to get rejected again.
+    /// The block is anchored a <see cref="GraceWindow"/> in the past so no new grace window is opened. As the backend does not
+    /// tell when exactly the next command is allowed, this blocks for the remaining <see cref="CommandWindow"/> minus
+    /// <see cref="GraceWindow"/>, which never blocks longer than a full command window.
+    /// </summary>
+    public void RecordRateLimited(DtoCar car)
+    {
+        logger.LogTrace("{method}({vin})", nameof(RecordRateLimited), car.Vin);
+        var lastCountedCommand = car.LastCountedFleetApiCommand;
+        var blockAnchor = dateTimeProvider.UtcNow() - GraceWindow;
+        //Never shorten an already known block, e.g. when the backend rejects a command sent within the local grace window.
+        if (lastCountedCommand == default || blockAnchor > lastCountedCommand.Value)
+        {
+            car.LastCountedFleetApiCommand = blockAnchor;
+        }
+    }
 }

--- a/TeslaSolarCharger/Server/Services/FleetApiRateLimitService.cs
+++ b/TeslaSolarCharger/Server/Services/FleetApiRateLimitService.cs
@@ -1,0 +1,50 @@
+using TeslaSolarCharger.Server.Services.Contracts;
+using TeslaSolarCharger.Shared.Contracts;
+using TeslaSolarCharger.Shared.Dtos.Settings;
+
+namespace TeslaSolarCharger.Server.Services;
+
+/// <summary>
+/// Rate limits Fleet API commands for BLE enabled cars without a Fleet API license: one counted successful command per
+/// <see cref="CommandWindow"/>. The first counted command opens a <see cref="GraceWindow"/> during which further commands
+/// are allowed without consuming the budget, so multi command sequences like wake up, set amps, charge start can complete.
+/// The same limits are enforced in the Solar4Car backend, so these values must not be changed without changing them there, too.
+/// </summary>
+public class FleetApiRateLimitService(
+    ILogger<FleetApiRateLimitService> logger,
+    IDateTimeProvider dateTimeProvider) : IFleetApiRateLimitService
+{
+    public static readonly TimeSpan CommandWindow = TimeSpan.FromMinutes(60);
+    public static readonly TimeSpan GraceWindow = TimeSpan.FromMinutes(5);
+
+    public DateTime? GetNextAllowedUtc(DtoCar car)
+    {
+        logger.LogTrace("{method}({vin})", nameof(GetNextAllowedUtc), car.Vin);
+        var lastCountedCommand = car.LastCountedFleetApiCommand;
+        if (lastCountedCommand == default)
+        {
+            return null;
+        }
+        var currentDate = dateTimeProvider.UtcNow();
+        if (currentDate < (lastCountedCommand.Value + GraceWindow))
+        {
+            return null;
+        }
+        if (currentDate >= (lastCountedCommand.Value + CommandWindow))
+        {
+            return null;
+        }
+        return lastCountedCommand.Value + CommandWindow;
+    }
+
+    public void RecordSuccessfulCommand(DtoCar car)
+    {
+        logger.LogTrace("{method}({vin})", nameof(RecordSuccessfulCommand), car.Vin);
+        var lastCountedCommand = car.LastCountedFleetApiCommand;
+        var currentDate = dateTimeProvider.UtcNow();
+        if (lastCountedCommand == default || currentDate >= (lastCountedCommand.Value + CommandWindow))
+        {
+            car.LastCountedFleetApiCommand = currentDate;
+        }
+    }
+}

--- a/TeslaSolarCharger/Server/Services/TeslaFleetApiService.cs
+++ b/TeslaSolarCharger/Server/Services/TeslaFleetApiService.cs
@@ -39,7 +39,8 @@ public class TeslaFleetApiService(
     ITokenHelper tokenHelper,
     IFleetTelemetryWebSocketService fleetTelemetryWebSocketService,
     IMemoryCache memoryCache,
-    IBackendApiService backendApiService)
+    IBackendApiService backendApiService,
+    IFleetApiRateLimitService fleetApiRateLimitService)
     : ITeslaService, ITeslaFleetApiService
 {
     private const string IsChargingErrorMessage = "is_charging";
@@ -761,109 +762,90 @@ public class TeslaFleetApiService(
         }
 
         var car = settings.Cars.First(c => c.Vin == vin);
-        if (!isFleetApiTest && fleetApiRequest.BleCompatible)
+        if (!isFleetApiTest && fleetApiRequest.BleCompatible && car.UseBle)
         {
-            
-            var isCarBleEnabled = car.UseBle;
-            if (isCarBleEnabled)
+            await errorHandlingService.HandleErrorResolved(issueKeys.FleetApiNotLicensed, car.Vin);
+            var result = new DtoBleCommandResult();
+            try
             {
-                await errorHandlingService.HandleErrorResolved(issueKeys.FleetApiNotLicensed, car.Vin);
-                //When changing this condition also change it in ErrorHandlingService.DetectErrors as there the error will be set to resolved.
-                if ((car.LastNonSuccessBleCall != default) && (car.LastNonSuccessBleCall.Value >
-                    (dateTimeProvider.UtcNow() - configurationWrapper.BleUsageStopAfterError())))
+                if (fleetApiRequest.RequestUrl == ChargeStartRequest.RequestUrl)
                 {
-                    logger.LogWarning("BLE is not used for car {carVin} as last non success BLE call was at {lastNonSuccessBleCall}", car.Vin, car.LastNonSuccessBleCall);
+                    result = await bleService.StartCharging(vin);
                 }
-                else
+                else if (fleetApiRequest.RequestUrl == ChargeStopRequest.RequestUrl)
                 {
-                    var result = new DtoBleCommandResult();
-                    try
-                    {
-                        if (fleetApiRequest.RequestUrl == ChargeStartRequest.RequestUrl)
-                        {
-                            result = await bleService.StartCharging(vin);
-                        }
-                        else if (fleetApiRequest.RequestUrl == ChargeStopRequest.RequestUrl)
-                        {
-                            result = await bleService.StopCharging(vin);
-                        }
-                        else if (fleetApiRequest.RequestUrl == SetChargingAmpsRequest.RequestUrl)
-                        {
-                            result = await bleService.SetAmp(vin, intParam!.Value);
-                        }
-                        else if (fleetApiRequest.RequestUrl == WakeUpRequest.RequestUrl)
-                        {
-                            result = await bleService.WakeUpCar(vin);
-                        }
+                    result = await bleService.StopCharging(vin);
+                }
+                else if (fleetApiRequest.RequestUrl == SetChargingAmpsRequest.RequestUrl)
+                {
+                    result = await bleService.SetAmp(vin, intParam!.Value);
+                }
+                else if (fleetApiRequest.RequestUrl == WakeUpRequest.RequestUrl)
+                {
+                    result = await bleService.WakeUpCar(vin);
+                }
 
-                        if (result.Success
-                            || (result.ErrorType == ErrorType.CarExecution
-                                && (fleetApiRequest.RequestUrl == ChargeStartRequest.RequestUrl)
-                                && (result.CarErrorMessage?.Contains(IsChargingErrorMessage) == true))
-                            || (result.ErrorType == ErrorType.CarExecution
-                                && (fleetApiRequest.RequestUrl == ChargeStopRequest.RequestUrl)
-                                && (result.CarErrorMessage?.Contains(IsNotChargingErrorMessage) == true)))
-                        {
-                            AddRequestToCar(vin, fleetApiRequest);
-                            await errorHandlingService.HandleErrorResolved(issueKeys.BleCommandNoSuccess + fleetApiRequest.RequestUrl, car.Vin);
-                            await errorHandlingService.HandleErrorResolved(issueKeys.UsingFleetApiAsBleFallback, car.Vin);
-                            if (typeof(T) == typeof(DtoVehicleCommandResult))
+                if (result.Success
+                    || (result.ErrorType == ErrorType.CarExecution
+                        && (fleetApiRequest.RequestUrl == ChargeStartRequest.RequestUrl)
+                        && (result.CarErrorMessage?.Contains(IsChargingErrorMessage) == true))
+                    || (result.ErrorType == ErrorType.CarExecution
+                        && (fleetApiRequest.RequestUrl == ChargeStopRequest.RequestUrl)
+                        && (result.CarErrorMessage?.Contains(IsNotChargingErrorMessage) == true)))
+                {
+                    AddRequestToCar(vin, fleetApiRequest);
+                    await errorHandlingService.HandleErrorResolved(issueKeys.BleCommandNoSuccess + fleetApiRequest.RequestUrl, car.Vin);
+                    if (typeof(T) == typeof(DtoVehicleCommandResult))
+                    {
+                        var comamndResult = new DtoGenericTeslaResponse<T> { Response = (T)(object)new DtoVehicleCommandResult()
                             {
-                                var comamndResult = new DtoGenericTeslaResponse<T> { Response = (T)(object)new DtoVehicleCommandResult()
-                                    {
-                                        //Do not use result.Success as on is_charging and not_charging errors this would be false but should be true
-                                        Result = true,
-                                        Reason = result.ResultMessage ?? string.Empty,
-                                    },
-                                };
-                                return comamndResult;
-                            }
-
-                            return new();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogError(ex, "Error while calling BLE API");
+                                //Do not use result.Success as on is_charging and not_charging errors this would be false but should be true
+                                Result = true,
+                                Reason = result.ResultMessage ?? string.Empty,
+                            },
+                        };
+                        return comamndResult;
                     }
 
-
-                    await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi), $"Error sending BLE command for car {car.Vin}",
-                        $"Sending command to tesla via BLE did not succeed. Fleet API URL would be: {fleetApiRequest.RequestUrl}. BLE Response: {result.ResultMessage}",
-                        issueKeys.BleCommandNoSuccess + fleetApiRequest.RequestUrl, car.Vin, null).ConfigureAwait(false);
-                    if (await backendApiService.IsFleetApiLicensed(car.Vin, true))
-                    {
-                        car.LastNonSuccessBleCall = dateTimeProvider.UtcNow();
-                        var fallbackUntilLocalTimeString =
-                            (car.LastNonSuccessBleCall + configurationWrapper.BleUsageStopAfterError()).Value.ToLocalTime();
-                        logger.LogWarning("Command BLE enabled but command did not succeed, using Fleet API as fallback until {fallbackUntil}.", fallbackUntilLocalTimeString);
-                        await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi),
-                            $"Using Fleet API as BLE fallback for car {car.Vin}",
-                            $"As the BLE command did not succeed, Fleet API is used as fallback until {fallbackUntilLocalTimeString}. Note: During this time it is not possible to retry BLE automatically. You need to go to the car settings page and test BLE access manually.",
-                            issueKeys.UsingFleetApiAsBleFallback, car.Vin, null).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        //Do not use Fleet API if not licensed
-                        logger.LogInformation("Do not use Fleet API as Fallback as Fleet API is not licensed for car {vin}", car.Vin);
-                        return null;
-                    }
-                    
+                    return new();
                 }
-                
             }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error while calling BLE API");
+            }
+
+
+            await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi), $"Error sending BLE command for car {car.Vin}",
+                $"Sending command to tesla via BLE did not succeed. Fleet API URL would be: {fleetApiRequest.RequestUrl}. BLE Response: {result.ResultMessage}",
+                issueKeys.BleCommandNoSuccess + fleetApiRequest.RequestUrl, car.Vin, null).ConfigureAwait(false);
+            logger.LogWarning("BLE command {command} for car {vin} did not succeed, using Fleet API as fallback.", fleetApiRequest.RequestUrl, car.Vin);
         }
 
         if (!isFleetApiTest
             && (fleetApiRequest.RequestUrl != VehicleRequest.RequestUrl)
             && (!await backendApiService.IsFleetApiLicensed(car.Vin, true)))
         {
-            await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi), $"Fleet API not licensed for car {car.Vin}",
-                "Can not send Fleet API commands to car as Fleet API is not licensed",
-                issueKeys.FleetApiNotLicensed, car.Vin, null).ConfigureAwait(false);
+            if (!car.UseBle || !IsRateLimitedWithoutCarLicense(fleetApiRequest))
+            {
+                await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi), $"Fleet API not licensed for car {car.Vin}",
+                    "Can not send Fleet API commands to car as Fleet API is not licensed",
+                    issueKeys.FleetApiNotLicensed, car.Vin, null).ConfigureAwait(false);
 
-            logger.LogError("Can not send Fleet API commands to car {vin} as car is not licensed", car.Vin);
-            return new() { Error = "FleetApiNotLicensed", ErrorDescription = "Fleet API is not licensed for this car, so no command was sent.", };
+                logger.LogError("Can not send Fleet API commands to car {vin} as car is not licensed", car.Vin);
+                return new() { Error = "FleetApiNotLicensed", ErrorDescription = "Fleet API is not licensed for this car, so no command was sent.", };
+            }
+            var nextAllowedUtc = fleetApiRateLimitService.GetNextAllowedUtc(car);
+            if (nextAllowedUtc != null)
+            {
+                var nextAllowedLocalTime = nextAllowedUtc.Value.ToLocalTime();
+                await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi),
+                    $"Fleet API commands rate limited for car {car.Vin}",
+                    $"As the car has no Fleet API license, Fleet API can only be used as BLE fallback for one command per hour. The command {fleetApiRequest.RequestUrl} was not sent, the next command is allowed at {nextAllowedLocalTime}. To remove this limit fix the BLE connection or buy a Fleet API license for the car.",
+                    issueKeys.FleetApiCommandRateLimited, car.Vin, null).ConfigureAwait(false);
+                logger.LogWarning("Do not send Fleet API command {command} to car {vin} as commands are rate limited until {nextAllowed}", fleetApiRequest.RequestUrl, car.Vin, nextAllowedLocalTime);
+                return new() { Error = "FleetApiCommandRateLimited", ErrorDescription = $"The car has no Fleet API license, so Fleet API fallback commands are rate limited. The next command is allowed at {nextAllowedLocalTime}.", };
+            }
         }
         await errorHandlingService.HandleErrorResolved(issueKeys.FleetApiNotLicensed, car.Vin);
 
@@ -898,6 +880,15 @@ public class TeslaFleetApiService(
         var backendResult = await backendApiService.SendRequestToBackend<DtoBackendApiTeslaResponse>(HttpMethod.Post, accessToken.AccessToken, requestUri, null).ConfigureAwait(false);
         if (backendResult.HasError)
         {
+            if (backendResult.ProblemDetails?.Status == (int)HttpStatusCode.TooManyRequests)
+            {
+                await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi),
+                    $"Fleet API commands rate limited for car {car.Vin}",
+                    $"The Solar4Car backend rejected the command {fleetApiRequest.RequestUrl} as rate limited: {backendResult.ErrorMessage}",
+                    issueKeys.FleetApiCommandRateLimited, car.Vin, null).ConfigureAwait(false);
+                logger.LogWarning("Backend rejected Fleet API command {command} for car {vin} as rate limited: {errorMessage}", fleetApiRequest.RequestUrl, car.Vin, backendResult.ErrorMessage);
+                return new() { Error = "FleetApiCommandRateLimited", ErrorDescription = backendResult.ErrorMessage, };
+            }
             await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi), $"Solar4Car related error while sending command to car {car.Vin}",
                 $"Sending command to Tesla API resulted in non succes status code. The issue very likely is not on Tesla's side but on Solar4Car side. Error Message: {backendResult.ErrorMessage} : Command name:{fleetApiRequest.RequestUrl}, Int Param:{intParam}.",
                 issueKeys.Solar4CarSideFleetApiNonSuccessStatusCode + fleetApiRequest.RequestUrl, car.Vin, null).ConfigureAwait(false);
@@ -950,10 +941,42 @@ public class TeslaFleetApiService(
             else
             {
                 await errorHandlingService.HandleErrorResolved(issueKeys.FleetApiNonSuccessResult + fleetApiRequest.RequestUrl, car.Vin);
+                await HandleSuccessfulFleetApiCommand(car, fleetApiRequest).ConfigureAwait(false);
             }
+        }
+        else
+        {
+            //No DtoVehicleCommandResult response (e.g. wake up), so the success status code means the command was successful.
+            await HandleSuccessfulFleetApiCommand(car, fleetApiRequest).ConfigureAwait(false);
         }
         logger.LogDebug("Response: {responseString}", backendApiResponse.JsonResponse);
         return teslaCommandResultResponse;
+    }
+
+    /// <summary>
+    /// Commands that count against the hourly Fleet API rate limit of BLE enabled cars without a Fleet API license.
+    /// Must match the commands the Solar4Car backend rate limits for unlicensed cars.
+    /// </summary>
+    private static bool IsRateLimitedWithoutCarLicense(DtoFleetApiRequest fleetApiRequest)
+    {
+        return fleetApiRequest.TeslaApiRequestType is TeslaApiRequestType.Charging
+            or TeslaApiRequestType.Command
+            or TeslaApiRequestType.WakeUp;
+    }
+
+    private async Task HandleSuccessfulFleetApiCommand(DtoCar car, DtoFleetApiRequest fleetApiRequest)
+    {
+        logger.LogTrace("{method}({vin}, {request})", nameof(HandleSuccessfulFleetApiCommand), car.Vin, fleetApiRequest.RequestUrl);
+        if (!IsRateLimitedWithoutCarLicense(fleetApiRequest))
+        {
+            return;
+        }
+        await errorHandlingService.HandleErrorResolved(issueKeys.FleetApiCommandRateLimited, car.Vin);
+        if (await backendApiService.IsFleetApiLicensed(car.Vin, true))
+        {
+            return;
+        }
+        fleetApiRateLimitService.RecordSuccessfulCommand(car);
     }
 
     public void ResetApiRequestCounters()

--- a/TeslaSolarCharger/Server/Services/TeslaFleetApiService.cs
+++ b/TeslaSolarCharger/Server/Services/TeslaFleetApiService.cs
@@ -882,6 +882,7 @@ public class TeslaFleetApiService(
         {
             if (backendResult.ProblemDetails?.Status == (int)HttpStatusCode.TooManyRequests)
             {
+                fleetApiRateLimitService.RecordRateLimited(car);
                 await errorHandlingService.HandleError(nameof(TeslaFleetApiService), nameof(SendCommandToTeslaApi),
                     $"Fleet API commands rate limited for car {car.Vin}",
                     $"The Solar4Car backend rejected the command {fleetApiRequest.RequestUrl} as rate limited: {backendResult.ErrorMessage}",

--- a/TeslaSolarCharger/Server/appsettings.json
+++ b/TeslaSolarCharger/Server/appsettings.json
@@ -37,7 +37,6 @@
   "MaxTravelSpeedMetersPerSecond": 30,
   //This is also the intervall for the car refresh
   "CarRefreshAfterCommandSeconds": 11,
-  "BleUsageStopAfterErrorSeconds": 300,
   "FleetApiRefreshIntervalSeconds": 500,
   "FleetTelemetryApiUrl": "https://api.fleet-telemetry.solar4car.com/fleet-hub",
   "BetaFleetTelemetryApiUrl": "https://beta.api.fleet-telemetry.solar4car.com/fleet-hub",

--- a/TeslaSolarCharger/Shared/Contracts/IConfigurationWrapper.cs
+++ b/TeslaSolarCharger/Shared/Contracts/IConfigurationWrapper.cs
@@ -105,7 +105,6 @@ public interface IConfigurationWrapper
     int MaxTravelSpeedMetersPerSecond();
     int CarRefreshAfterCommandSeconds();
     bool SendStackTraceToTelegram();
-    TimeSpan BleUsageStopAfterError();
     bool UseTeslaMateIntegration();
     string FleetTelemetryApiUrl();
     bool AllowPowerBufferChangeOnHome();

--- a/TeslaSolarCharger/Shared/Dtos/Settings/DtoCar.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Settings/DtoCar.cs
@@ -88,5 +88,9 @@ public class DtoCar
     public List<DateTime> SetChargingAmpsCall { get; set; } = new List<DateTime>();
     public List<DateTime> OtherCommandCalls { get; set; } = new List<DateTime>();
 
-    public DateTime? LastNonSuccessBleCall { get; set; }
+    /// <summary>
+    /// Last successful Fleet API command that consumed the hourly rate limit budget for cars without a Fleet API license.
+    /// Only kept in memory as the Solar4Car backend enforces the rate limit across restarts.
+    /// </summary>
+    public DateTime? LastCountedFleetApiCommand { get; set; }
 }

--- a/TeslaSolarCharger/Shared/Wrappers/ConfigurationWrapper.cs
+++ b/TeslaSolarCharger/Shared/Wrappers/ConfigurationWrapper.cs
@@ -180,13 +180,6 @@ public class ConfigurationWrapper(
         return value;
     }
 
-    public TimeSpan BleUsageStopAfterError()
-    {
-        var environmentVariableName = "BleUsageStopAfterErrorSeconds";
-        var value = configuration.GetValue<int>(environmentVariableName);
-        return TimeSpan.FromSeconds(value);
-    }
-
     public TimeSpan FleetApiRefreshInterval()
     {
         var environmentVariableName = "FleetApiRefreshIntervalSeconds";


### PR DESCRIPTION
- BLE enabled cars without a Fleet API license can send one successful Fleet API command per hour; the first counted command opens a 5 minute grace window so wake up, set amps and charge start sequences complete
- only successful commands consume the hourly budget, failed attempts can be retried immediately
- always try BLE first for licensed and unlicensed cars: remove LastNonSuccessBleCall pause mechanism incl. BleUsageStopAfterErrorSeconds config and UsingFleetApiAsBleFallback issue key
- new issue key FleetApiCommandRateLimited shows when the next command is allowed and resolves on the next successful command; backend 429 responses map to the same issue key

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
