### PR TITLE
fix(cars): show progress and result when importing Teslas

### DIFF
--- a/TeslaSolarCharger/Client/Components/CarManagementComponent.razor
+++ b/TeslaSolarCharger/Client/Components/CarManagementComponent.razor
@@ -118,7 +118,11 @@ else
             await RefreshFleetApiTokenState();
             if (_fleetApiTokenState == TokenState.UpToDate)
             {
-                await CarSettingsService.RefreshTeslaCarsFromAccount();
+                var addedCars = await CarSettingsService.RefreshTeslaCarsFromAccount();
+                if (addedCars != null)
+                {
+                    Snackbar.Add(CarSettingsService.GetAddedTeslasMessage(addedCars.Value), Severity.Success);
+                }
             }
             DropQueryParam(Constants.QueryParamTeslaConnected);
         }

--- a/TeslaSolarCharger/Client/Dialogs/AddCarDialog.razor
+++ b/TeslaSolarCharger/Client/Dialogs/AddCarDialog.razor
@@ -45,7 +45,18 @@
             }
             else if (_step == Step.Tesla)
             {
-                @if (_isLoadingTeslaState)
+                @if (_isAddingTeslas)
+                {
+                    <MudText Typo="Typo.body2" Class="mb-3">@T(TranslationKeys.CarSettingsAddTeslaFromAccountLoading)</MudText>
+                    <LoadingSpinnerComponent />
+                }
+                else if (_addedTeslasCount != null)
+                {
+                    <MudAlert Severity="Severity.Success" NoIcon="true" ContentAlignment="HorizontalAlignment.Left">
+                        @CarSettingsService.GetAddedTeslasMessage(_addedTeslasCount.Value)
+                    </MudAlert>
+                }
+                else if (_isLoadingTeslaState)
                 {
                     <LoadingSpinnerComponent />
                 }
@@ -100,28 +111,36 @@
         </div>
     </DialogContent>
     <DialogActions>
-        @if (_step != Step.ChooseType)
+        @if (_step == Step.Tesla && _addedTeslasCount != null)
         {
-            <MudButton OnClick="GoBack" Disabled="_isBusy">@T(TranslationKeys.AddCarBackButton)</MudButton>
+            @* The import is done: the only sensible action left is closing the dialog, which refreshes the car list. *@
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="CloseAfterImport">@T(TranslationKeys.GeneralClose)</MudButton>
         }
-        <MudButton OnClick="Cancel" Disabled="_isBusy">@T(TranslationKeys.GeneralCancel)</MudButton>
-        @if (_step == Step.Tesla && _fleetApiTokenState == TokenState.UpToDate)
+        else
         {
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="AddTeslasFromAccount" Disabled="_isBusy">
-                @T(TranslationKeys.CarSettingsAddTeslaFromAccountButton)
-            </MudButton>
-        }
-        else if (_step == Step.Tesla && _fleetApiTokenState is not null and not TokenState.MissingPrecondition)
-        {
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="ConnectTeslaAccount" Disabled="_isBusy">
-                @T(TranslationKeys.AddCarConnectTeslaButton)
-            </MudButton>
-        }
-        else if (_step == Step.SmartCar)
-        {
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="ConnectSmartCar" Disabled="_isBusy || _selectedVehicle == null">
-                @T(TranslationKeys.AddCarSmartCarConnectButton)
-            </MudButton>
+            @if (_step != Step.ChooseType)
+            {
+                <MudButton OnClick="GoBack" Disabled="_isBusy">@T(TranslationKeys.AddCarBackButton)</MudButton>
+            }
+            <MudButton OnClick="Cancel" Disabled="_isBusy">@T(TranslationKeys.GeneralCancel)</MudButton>
+            @if (_step == Step.Tesla && _fleetApiTokenState == TokenState.UpToDate)
+            {
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="AddTeslasFromAccount" Disabled="_isBusy">
+                    @T(TranslationKeys.CarSettingsAddTeslaFromAccountButton)
+                </MudButton>
+            }
+            else if (_step == Step.Tesla && _fleetApiTokenState is not null and not TokenState.MissingPrecondition)
+            {
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="ConnectTeslaAccount" Disabled="_isBusy">
+                    @T(TranslationKeys.AddCarConnectTeslaButton)
+                </MudButton>
+            }
+            else if (_step == Step.SmartCar)
+            {
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="ConnectSmartCar" Disabled="_isBusy || _selectedVehicle == null">
+                    @T(TranslationKeys.AddCarSmartCarConnectButton)
+                </MudButton>
+            }
         }
     </DialogActions>
 </MudDialog>
@@ -144,6 +163,13 @@
     private bool _isLoadingTeslaState;
     private bool _teslaStateLoaded;
     private bool _isBusy;
+    private bool _isAddingTeslas;
+
+    /// <summary>
+    /// Number of cars the last import added. Not null as soon as the import finished successfully, which switches
+    /// the Tesla step to its result view.
+    /// </summary>
+    private int? _addedTeslasCount;
 
     private List<DtoSmartCarCompatibleVehicle>? _compatibleVehicles;
     private bool _isLoadingCompatibleVehicles;
@@ -174,6 +200,7 @@
     {
         _step = Step.ChooseType;
         _selectedVehicle = null;
+        _addedTeslasCount = null;
     }
 
     private Task ChooseManual()
@@ -224,13 +251,16 @@
     private async Task AddTeslasFromAccount()
     {
         _isBusy = true;
-        var success = await CarSettingsService.RefreshTeslaCarsFromAccount();
+        // Importing needs a round trip to the Tesla account and can take several seconds, so show a spinner
+        // instead of only disabling the button, and keep the dialog open afterwards to report the result.
+        _isAddingTeslas = true;
+        var addedCars = await CarSettingsService.RefreshTeslaCarsFromAccount();
+        _isAddingTeslas = false;
         _isBusy = false;
-        if (success)
-        {
-            MudDialog.Close(DialogResult.Ok(AddCarResultAction.Refresh));
-        }
+        _addedTeslasCount = addedCars;
     }
+
+    private void CloseAfterImport() => MudDialog.Close(DialogResult.Ok(AddCarResultAction.Refresh));
 
     private async Task ConnectSmartCar()
     {

--- a/TeslaSolarCharger/Client/Services/CarSettingsService.cs
+++ b/TeslaSolarCharger/Client/Services/CarSettingsService.cs
@@ -131,16 +131,25 @@ public class CarSettingsService(ILogger<CarSettingsService> logger,
         await httpClientHelper.SendPostRequestAsync<object>("api/Config/SyncSmartCarCars", null);
     }
 
-    public async Task<bool> RefreshTeslaCarsFromAccount()
+    public async Task<int?> RefreshTeslaCarsFromAccount()
     {
         logger.LogTrace("{method}()", nameof(RefreshTeslaCarsFromAccount));
-        var result = await httpClientHelper.SendPostRequestAsync<object>("api/Config/RefreshTeslaCarsFromAccount", null);
+        var result = await httpClientHelper.SendPostRequestAsync<DtoValue<int>>("api/Config/RefreshTeslaCarsFromAccount", null);
         if (result.HasError)
         {
             snackbar.Add(TF(TranslationKeys.CarSettingsAddTeslaFromAccountError, result.ErrorMessage ?? string.Empty), Severity.Error);
-            return false;
+            return null;
         }
-        snackbar.Add(TF(TranslationKeys.CarSettingsAddTeslaFromAccountSuccess), Severity.Success);
-        return true;
+        return result.Data?.Value ?? 0;
+    }
+
+    public string GetAddedTeslasMessage(int addedCarsCount)
+    {
+        return addedCarsCount switch
+        {
+            0 => TF(TranslationKeys.CarSettingsAddTeslaFromAccountNoNewCars),
+            1 => TF(TranslationKeys.CarSettingsAddTeslaFromAccountOneCarAdded),
+            _ => TF(TranslationKeys.CarSettingsAddTeslaFromAccountCarsAdded, addedCarsCount),
+        };
     }
 }

--- a/TeslaSolarCharger/Client/Services/Contracts/ICarSettingsService.cs
+++ b/TeslaSolarCharger/Client/Services/Contracts/ICarSettingsService.cs
@@ -22,5 +22,15 @@ public interface ICarSettingsService
     Task<string?> GetSmartCarOAuthRedeemUrlForNewCar(string baseUrl);
     Task<List<DtoSmartCarCompatibleVehicle>?> GetSmartCarCompatibleVehicles();
     Task SyncSmartCarCars();
-    Task<bool> RefreshTeslaCarsFromAccount();
+
+    /// <summary>
+    /// Imports all cars of the connected Tesla account that are not known to TSC yet.
+    /// </summary>
+    /// <returns>The number of newly added cars, or <c>null</c> if the import failed.</returns>
+    Task<int?> RefreshTeslaCarsFromAccount();
+
+    /// <summary>
+    /// Localized message telling the user how many cars were added by <see cref="RefreshTeslaCarsFromAccount"/>.
+    /// </summary>
+    string GetAddedTeslasMessage(int addedCarsCount);
 }

--- a/TeslaSolarCharger/Server/Controllers/ConfigController.cs
+++ b/TeslaSolarCharger/Server/Controllers/ConfigController.cs
@@ -23,12 +23,13 @@ namespace TeslaSolarCharger.Server.Controllers
         /// Discover and add cars that are present in the connected Tesla account but not yet in TSC.
         /// Mirrors the discovery that runs at startup, so users can pick up newly added Teslas without restarting.
         /// </summary>
+        /// <returns>The number of cars that were newly added.</returns>
         [HttpPost]
-        public async Task<IActionResult> RefreshTeslaCarsFromAccount()
+        public async Task<ActionResult<DtoValue<int>>> RefreshTeslaCarsFromAccount()
         {
-            await carConfigurationService.AddAllMissingCarsFromTeslaAccount().ConfigureAwait(false);
+            var addedCars = await carConfigurationService.AddAllMissingCarsFromTeslaAccount().ConfigureAwait(false);
             await configJsonService.AddCarsToSettings(null).ConfigureAwait(false);
-            return Ok();
+            return Ok(new DtoValue<int>(addedCars));
         }
 
         /// <summary>

--- a/TeslaSolarCharger/Server/Services/CarConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/CarConfigurationService.cs
@@ -14,7 +14,7 @@ public class CarConfigurationService(ILogger<CarConfigurationService> logger,
     IConfigurationWrapper configurationWrapper,
     ITeslaMateDbContextWrapper teslaMateDbContextWrapper) : ICarConfigurationService
 {
-    public async Task AddAllMissingCarsFromTeslaAccount()
+    public async Task<int> AddAllMissingCarsFromTeslaAccount()
     {
         logger.LogTrace("{method}()", nameof(AddAllMissingCarsFromTeslaAccount));
         var teslaMateCars = new List<Model.Entities.TeslaMate.Car>();
@@ -57,6 +57,7 @@ public class CarConfigurationService(ILogger<CarConfigurationService> logger,
                 .FirstOrDefault(c => string.Equals(c.Vin, teslaSolarChargerCar.Vin, StringComparison.CurrentCultureIgnoreCase))?.Id;
         }
         await teslaSolarChargerContext.SaveChangesAsync();
+        var addedCarsCount = 0;
         foreach (var teslaAccountCar in teslaAccountCars)
         {
             var teslaSolarChargerCar = teslaSolarChargerCars.FirstOrDefault(c => string.Equals(c.Vin, teslaAccountCar.Vin, StringComparison.CurrentCultureIgnoreCase));
@@ -89,6 +90,7 @@ public class CarConfigurationService(ILogger<CarConfigurationService> logger,
             };
             teslaSolarChargerContext.Cars.Add(teslaSolarChargerCar);
             await teslaSolarChargerContext.SaveChangesAsync();
+            addedCarsCount++;
         }
 
         foreach (var teslaSolarChargerCar in teslaSolarChargerCars)
@@ -106,5 +108,7 @@ public class CarConfigurationService(ILogger<CarConfigurationService> logger,
                 await teslaSolarChargerContext.SaveChangesAsync();
             }
         }
+
+        return addedCarsCount;
     }
 }

--- a/TeslaSolarCharger/Server/Services/Contracts/ICarConfigurationService.cs
+++ b/TeslaSolarCharger/Server/Services/Contracts/ICarConfigurationService.cs
@@ -2,5 +2,9 @@
 
 public interface ICarConfigurationService
 {
-    Task AddAllMissingCarsFromTeslaAccount();
+    /// <summary>
+    /// Adds all cars of the connected Tesla account that are not known to TSC yet.
+    /// </summary>
+    /// <returns>The number of cars that were newly added.</returns>
+    Task<int> AddAllMissingCarsFromTeslaAccount();
 }

--- a/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
@@ -228,9 +228,21 @@ public class CarSettingsPageLocalizationRegistry : TextLocalizationRegistry<CarS
             new TextLocalizationTranslation(LanguageCodes.English, "Add cars from Tesla account"),
             new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeuge aus Tesla-Konto hinzufügen"));
 
-        Register(TranslationKeys.CarSettingsAddTeslaFromAccountSuccess,
-            new TextLocalizationTranslation(LanguageCodes.English, "Checked your Tesla account for new cars."),
-            new TextLocalizationTranslation(LanguageCodes.German, "Tesla-Konto auf neue Fahrzeuge geprüft."));
+        Register(TranslationKeys.CarSettingsAddTeslaFromAccountLoading,
+            new TextLocalizationTranslation(LanguageCodes.English, "Loading cars from your Tesla account. This can take a few seconds."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeuge werden aus Ihrem Tesla-Konto geladen. Das kann einige Sekunden dauern."));
+
+        Register(TranslationKeys.CarSettingsAddTeslaFromAccountNoNewCars,
+            new TextLocalizationTranslation(LanguageCodes.English, "No new cars found in your Tesla account."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Keine neuen Fahrzeuge in Ihrem Tesla-Konto gefunden."));
+
+        Register(TranslationKeys.CarSettingsAddTeslaFromAccountOneCarAdded,
+            new TextLocalizationTranslation(LanguageCodes.English, "1 car was added."),
+            new TextLocalizationTranslation(LanguageCodes.German, "1 Fahrzeug wurde hinzugefügt."));
+
+        Register(TranslationKeys.CarSettingsAddTeslaFromAccountCarsAdded,
+            new TextLocalizationTranslation(LanguageCodes.English, "{0} cars were added."),
+            new TextLocalizationTranslation(LanguageCodes.German, "{0} Fahrzeuge wurden hinzugefügt."));
 
         Register(TranslationKeys.CarSettingsAddTeslaFromAccountError,
             new TextLocalizationTranslation(LanguageCodes.English, "Could not load cars from your Tesla account: {0}"),

--- a/TeslaSolarCharger/Shared/Localization/Registries/SharedComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/SharedComponentLocalizationRegistry.cs
@@ -34,6 +34,10 @@ public class SharedComponentLocalizationRegistry : TextLocalizationRegistry<Shar
             new TextLocalizationTranslation(LanguageCodes.English, "Cancel"),
             new TextLocalizationTranslation(LanguageCodes.German, "Abbrechen"));
 
+        Register(TranslationKeys.GeneralClose,
+            new TextLocalizationTranslation(LanguageCodes.English, "Close"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Schließen"));
+
         Register(TranslationKeys.GeneralProcessing,
             new TextLocalizationTranslation(LanguageCodes.English, "Processing"),
             new TextLocalizationTranslation(LanguageCodes.German, "Wird verarbeitet"));

--- a/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
+++ b/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
@@ -306,7 +306,10 @@ public static class TranslationKeys
     public static string CarSettingsSmartCarDisconnectSuccess => nameof(CarSettingsSmartCarDisconnectSuccess);
     public static string CarSettingsSmartCarUrlMissingError => nameof(CarSettingsSmartCarUrlMissingError);
     public static string CarSettingsAddTeslaFromAccountButton => nameof(CarSettingsAddTeslaFromAccountButton);
-    public static string CarSettingsAddTeslaFromAccountSuccess => nameof(CarSettingsAddTeslaFromAccountSuccess);
+    public static string CarSettingsAddTeslaFromAccountLoading => nameof(CarSettingsAddTeslaFromAccountLoading);
+    public static string CarSettingsAddTeslaFromAccountNoNewCars => nameof(CarSettingsAddTeslaFromAccountNoNewCars);
+    public static string CarSettingsAddTeslaFromAccountOneCarAdded => nameof(CarSettingsAddTeslaFromAccountOneCarAdded);
+    public static string CarSettingsAddTeslaFromAccountCarsAdded => nameof(CarSettingsAddTeslaFromAccountCarsAdded);
     public static string CarSettingsAddTeslaFromAccountError => nameof(CarSettingsAddTeslaFromAccountError);
     public static string CarSettingsSmartCarBillingConfirmTitle => nameof(CarSettingsSmartCarBillingConfirmTitle);
     public static string CarSettingsSmartCarBillingConfirmText => nameof(CarSettingsSmartCarBillingConfirmText);
@@ -661,6 +664,7 @@ public static class TranslationKeys
 
     public static string GeneralSave => nameof(GeneralSave);
     public static string GeneralCancel => nameof(GeneralCancel);
+    public static string GeneralClose => nameof(GeneralClose);
     public static string GeneralProcessing => nameof(GeneralProcessing);
     public static string GeneralSaved => nameof(GeneralSaved);
     public static string GeneralLoading => nameof(GeneralLoading);


### PR DESCRIPTION
Fixes #2824

Importing the cars of a Tesla account needs a round trip to Tesla and can take several seconds. Until now the button was only disabled while it ran, so the dialog looked frozen and the imported cars showed up out of nowhere on the next page load.

- `RefreshTeslaCarsFromAccount` returns the number of newly added cars now (`AddAllMissingCarsFromTeslaAccount` counts them).
- The dialog shows a spinner with a hint that this can take a few seconds while the import runs.
- Afterwards it reports the result and offers a Close button that refreshes the car list: *No new cars found in your Tesla account.* / *1 car was added.* / *{n} cars were added.*
- The Tesla OAuth return path shows the same message as a snackbar instead of the old generic "Checked your Tesla account for new cars."

🤖 Generated with [Claude Code](https://claude.com/claude-code)