### PR TITLE
fix(templates): re-render template edit forms on field change

### DIFF
--- a/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Templates/ConfigurationEditForms/Contracts/TemplateEditFormComponentBase.razor
+++ b/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Templates/ConfigurationEditForms/Contracts/TemplateEditFormComponentBase.razor
@@ -1,5 +1,7 @@
 ﻿@implements ITemplateEditFormComponent
+@implements IDisposable
 
+@using Microsoft.AspNetCore.Components.Forms
 @using Newtonsoft.Json.Linq
 @using TeslaSolarCharger.Client.Wrapper
 
@@ -41,6 +43,20 @@
         }
         Configuration ??= new();
         WrappedConfiguration = new(Configuration);
+        //The inputs write directly into the configuration object without notifying this component, so re-render on
+        //every field change. Otherwise inputs that are only rendered for a certain value (e.g. the battery power
+        //fields behind the home battery control switch) would not appear or disappear when that value is changed.
+        WrappedConfiguration.EditContext.OnFieldChanged += HandleFieldChanged;
+    }
+
+    private void HandleFieldChanged(object? sender, FieldChangedEventArgs args) => StateHasChanged();
+
+    public void Dispose()
+    {
+        if (WrappedConfiguration != default)
+        {
+            WrappedConfiguration.EditContext.OnFieldChanged -= HandleFieldChanged;
+        }
     }
 
     public bool Validate()


### PR DESCRIPTION
Fixes #2849

The inputs write straight into the configuration object, so the form was never told that a value changed. Conditional inputs therefore kept their last rendered state: enabling *Enable home battery control* did not show the max battery charge and discharge power fields and disabling it did not remove them.

Fixed centrally in `TemplateEditFormComponentBase`, which now re-renders whenever the edit context reports a changed field, so every conditional input of every template edit form is covered (Fronius, GenericModbus, GenericRest, Kostal, SMA, SunSpec, Tesla Powerwall) instead of adding the same workaround seven times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)