### PR TITLE
fix(templates): add unit suffixes to template value configurations

### DIFF
--- a/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Generic/DtoGenericModbusTemplateValueConfiguration.cs
+++ b/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Generic/DtoGenericModbusTemplateValueConfiguration.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using TeslaSolarCharger.Shared.Attributes;
 
 namespace TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.Generic;
 
@@ -13,7 +14,9 @@ public class DtoGenericModbusTemplateValueConfiguration : DtoModbusConfiguration
     /// charging of the home battery.
     /// </summary>
     public bool EnableHomeBatteryControl { get; set; }
+    [Postfix("W")]
     public int MaxBatteryChargePowerW { get; set; } = 4200;
+    [Postfix("W")]
     public int MaxBatteryDischargePowerW { get; set; } = 4200;
 }
 

--- a/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Generic/DtoGenericRestTemplateValueConfiguration.cs
+++ b/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Generic/DtoGenericRestTemplateValueConfiguration.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using System.ComponentModel.DataAnnotations;
+using TeslaSolarCharger.Shared.Attributes;
 using TeslaSolarCharger.Shared.Helper;
 
 namespace TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.Generic;
@@ -19,6 +20,7 @@ public class DtoGenericRestTemplateValueConfiguration
     public string? ApiToken { get; set; }
     public int DeviceId { get; set; }
     public bool EnableHomeBatteryControl { get; set; }
+    [Postfix("W")]
     public int MaxBatteryChargePowerW { get; set; } = 3300;
 }
 

--- a/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Generic/DtoSunSpecTemplateValueConfiguration.cs
+++ b/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Generic/DtoSunSpecTemplateValueConfiguration.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using TeslaSolarCharger.Shared.Attributes;
 using TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.Generic;
 
 namespace TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.Generic;
@@ -13,15 +14,18 @@ public class DtoSunSpecTemplateValueConfiguration : DtoModbusConfigurationBase
     /// <summary>
     /// Charge rate in percent for SunSpec model 124 based control (device charges at this percentage of its max rate).
     /// </summary>
+    [Postfix("%")]
     public int MaxChargeRatePercent { get; set; } = 100;
     /// <summary>
     /// Max charge power in watts for vendors using plain register control (e.g. Kostal Plenticore Gen2).
     /// </summary>
+    [Postfix("W")]
     public int MaxBatteryChargePowerW { get; set; } = 4200;
     /// <summary>
     /// Max discharge power in watts that is restored in normal mode for vendors using a discharge limit
     /// (e.g. SolarEdge).
     /// </summary>
+    [Postfix("W")]
     public int MaxBatteryDischargePowerW { get; set; } = 5000;
 }
 

--- a/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Kostal/DtoKostalModbusConfiguration.cs
+++ b/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Kostal/DtoKostalModbusConfiguration.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using TeslaSolarCharger.Shared.Attributes;
 using TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.Generic;
 
 namespace TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.Kostal;
@@ -16,6 +17,7 @@ public class DtoKostalModbusConfiguration : DtoModbusConfigurationBase
     /// management via Modbus to be activated in the inverter's installer settings.
     /// </summary>
     public bool EnableHomeBatteryControl { get; set; }
+    [Postfix("W")]
     public int MaxBatteryChargePowerW { get; set; } = 4200;
 }
 

--- a/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Sma/DtoSmaInverterTemplateValueConfiguration.cs
+++ b/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/Sma/DtoSmaInverterTemplateValueConfiguration.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using TeslaSolarCharger.Shared.Attributes;
 using TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.Generic;
 
 namespace TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.Sma;
@@ -15,7 +16,9 @@ public class DtoSmaInverterTemplateValueConfiguration : DtoModbusConfigurationBa
     /// Only relevant for hybrid inverters. When enabled TSC can block discharging and force charging of the home battery.
     /// </summary>
     public bool EnableHomeBatteryControl { get; set; }
+    [Postfix("W")]
     public int MaxBatteryChargePowerW { get; set; } = 4200;
+    [Postfix("W")]
     public int MaxBatteryDischargePowerW { get; set; } = 4200;
 }
 

--- a/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/TeslaPowerwall/DtoTeslaPowerwallTemplateValueConfiguration.cs
+++ b/TeslaSolarCharger/Shared/Dtos/TemplateConfiguration/TeslaPowerwall/DtoTeslaPowerwallTemplateValueConfiguration.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using TeslaSolarCharger.Shared.Attributes;
 
 namespace TeslaSolarCharger.Shared.Dtos.TemplateConfiguration.TeslaPowerwall;
 
@@ -13,6 +14,7 @@ public class DtoTeslaPowerwallTemplateValueConfiguration
     /// <summary>
     /// Backup reserve percent that is restored when no battery mode is forced.
     /// </summary>
+    [Postfix("%")]
     public int NormalModeBackupReservePercent { get; set; } = 20;
 }
 


### PR DESCRIPTION
Fixes #2850

The power and percentage inputs of the template value configurations were rendered without a unit, so it was not clear whether e.g. the max battery charge power is expected in W or kW. They use the same `[Postfix]` adornment the base configuration inputs already use now:

- `MaxBatteryChargePowerW` / `MaxBatteryDischargePowerW` (GenericModbus, GenericRest, Kostal, SMA inverter, SunSpec) → `W`
- `MaxChargeRatePercent` (SunSpec) → `%`
- `NormalModeBackupReservePercent` (Tesla Powerwall) → `%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)