### PR TITLE
feat(cars): test Fleet API access when a Tesla becomes managed

### DIFF
--- a/TeslaSolarCharger.Tests/Services/Server/TeslaBleServiceTests.cs
+++ b/TeslaSolarCharger.Tests/Services/Server/TeslaBleServiceTests.cs
@@ -1,0 +1,174 @@
+using PkSoftwareService.Custom.Backend.Ble;
+using System.Collections.Generic;
+using TeslaSolarCharger.Server.Services;
+using TeslaSolarCharger.Shared.Dtos.Ble;
+using Xunit;
+
+namespace TeslaSolarCharger.Tests.Services.Server;
+
+
+/// <summary>
+/// Covers how a failed BLE request is turned into something the user can act on. Getting this wrong sends people
+/// looking for the wrong problem, e.g. re-pairing a key for a car that simply is not at home.
+/// </summary>
+public class TeslaBleServiceTests : TestBase
+{
+    private const string TestVin = "TESTVIN123456789A";
+
+    public TeslaBleServiceTests(ITestOutputHelper outputHelper)
+        : base(outputHelper)
+    {
+    }
+
+    [Fact]
+    public void ReadableChargeStateMeansEverythingWorks()
+    {
+        var result = TeslaBleService.ClassifyChargeState(new DtoBleCommandResult { Success = true, });
+
+        Assert.Equal(BleConnectionTestResultType.Success, result);
+    }
+
+    [Theory]
+    [InlineData(BleCommandOutcome.AdapterNotFound)]
+    [InlineData(BleCommandOutcome.AdapterUnavailable)]
+    [InlineData(BleCommandOutcome.WorkerError)]
+    [InlineData(BleCommandOutcome.WorkerTimeout)]
+    [InlineData(BleCommandOutcome.InvalidRequest)]
+    public void LocalProblemsAreReportedAsContainerProblem(BleCommandOutcome outcome)
+    {
+        var result = TeslaBleService.ClassifyChargeState(new DtoBleCommandResult { Success = false, Outcome = outcome, });
+
+        Assert.Equal(BleConnectionTestResultType.ContainerProblem, result);
+    }
+
+    [Fact]
+    public void SleepingCarNeedsNoFurtherChecks()
+    {
+        var result = TeslaBleService.ClassifyChargeState(new DtoBleCommandResult
+        {
+            Success = false,
+            Outcome = BleCommandOutcome.CarAsleep,
+        });
+
+        Assert.Equal(BleConnectionTestResultType.CarAsleep, result);
+    }
+
+    [Theory]
+    [InlineData(BleCommandOutcome.CarAbsent)]
+    [InlineData(BleCommandOutcome.LinkFailed)]
+    [InlineData(BleCommandOutcome.CarRefused)]
+    [InlineData(null)]
+    public void UnclearOutcomesAreNarrowedDownFurther(BleCommandOutcome? outcome)
+    {
+        var result = TeslaBleService.ClassifyChargeState(new DtoBleCommandResult { Success = false, Outcome = outcome, });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void CarThatWasNotHeardIsReportedAsNotFound()
+    {
+        var presence = CreatePresence(heard: false);
+
+        var result = TeslaBleService.ClassifyPresence(presence, TestVin);
+
+        Assert.Equal(BleConnectionTestResultType.CarNotFound, result);
+    }
+
+    [Fact]
+    public void WarmingUpScanNeverDeclaresACarAway()
+    {
+        var presence = CreatePresence(heard: false);
+        presence.WarmingUp = true;
+
+        var result = TeslaBleService.ClassifyPresence(presence, TestVin);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void HeardCarIsNarrowedDownFurther()
+    {
+        var presence = CreatePresence(heard: true);
+
+        var result = TeslaBleService.ClassifyPresence(presence, TestVin);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void StoppedScannerCarriesNoPresenceInformation()
+    {
+        var presence = CreatePresence(heard: false);
+        presence.ScannerRunning = false;
+
+        var result = TeslaBleService.ClassifyPresence(presence, TestVin);
+
+        Assert.Equal(BleConnectionTestResultType.ContainerProblem, result);
+    }
+
+    [Fact]
+    public void UnreachableContainerIsNoStatementAboutTheCar()
+    {
+        var presence = CreatePresence(heard: false);
+        presence.ErrorMessage = "container not reachable";
+
+        var result = TeslaBleService.ClassifyPresence(presence, TestVin);
+
+        Assert.Equal(BleConnectionTestResultType.ContainerProblem, result);
+    }
+
+    [Fact]
+    public void PresentCarWithoutBodyControllerAnswerMeansMissingKey()
+    {
+        var bodyControllerState = new DtoBleCommandResult
+        {
+            Success = false,
+            Outcome = BleCommandOutcome.LinkFailed,
+            ResultMessage = "failed to connect: vehicle rejected request: your public key has not been paired with the vehicle",
+        };
+
+        var result = TeslaBleService.ClassifyBodyControllerState(bodyControllerState, isAwake: false);
+
+        Assert.Equal(BleConnectionTestResultType.KeyNotPaired, result);
+    }
+
+    [Fact]
+    public void CarThatLeftBetweenTheRequestsIsNotBlamedOnTheKey()
+    {
+        var bodyControllerState = new DtoBleCommandResult { Success = false, Outcome = BleCommandOutcome.CarAbsent, };
+
+        var result = TeslaBleService.ClassifyBodyControllerState(bodyControllerState, isAwake: false);
+
+        Assert.Equal(BleConnectionTestResultType.CarNotFound, result);
+    }
+
+    [Fact]
+    public void AnsweringBodyControllerOfASleepingCarMeansTheKeyWorks()
+    {
+        var bodyControllerState = new DtoBleCommandResult { Success = true, Outcome = BleCommandOutcome.Ok, };
+
+        var result = TeslaBleService.ClassifyBodyControllerState(bodyControllerState, isAwake: false);
+
+        Assert.Equal(BleConnectionTestResultType.CarAsleep, result);
+    }
+
+    [Fact]
+    public void AwakeCarWithWorkingKeyButFailedChargeStateStaysUnknown()
+    {
+        var bodyControllerState = new DtoBleCommandResult { Success = true, Outcome = BleCommandOutcome.Ok, };
+
+        var result = TeslaBleService.ClassifyBodyControllerState(bodyControllerState, isAwake: true);
+
+        Assert.Equal(BleConnectionTestResultType.Unknown, result);
+    }
+
+    private static DtoBlePresenceResult CreatePresence(bool heard) => new()
+    {
+        ScannerRunning = true,
+        Vehicles = new List<DtoBlePresenceVehicle>
+        {
+            new() { Vin = TestVin, Heard = heard, },
+        },
+    };
+}

--- a/TeslaSolarCharger/Client/Components/BleConnectionTestComponent.razor
+++ b/TeslaSolarCharger/Client/Components/BleConnectionTestComponent.razor
@@ -1,0 +1,151 @@
+@using System.Globalization
+@using TeslaSolarCharger.Client.Services.Contracts
+@using TeslaSolarCharger.Shared.Dtos.Ble
+@using TeslaSolarCharger.Shared.Localization
+@using TeslaSolarCharger.Shared.Localization.Contracts
+@using TeslaSolarCharger.Shared.Localization.Registries
+@using TeslaSolarCharger.Shared.Localization.Registries.Components
+
+@inject ICarSettingsService CarSettingsService
+@inject ITextLocalizationService TextLocalizer
+
+@if (_isTesting)
+{
+    <MudText Typo="Typo.body2" Class="mb-2">@T(TranslationKeys.BleTestTesting)</MudText>
+    <LoadingSpinnerComponent />
+}
+else if (_result != null)
+{
+    @if (_result.ResultType == BleConnectionTestResultType.Success)
+    {
+        <MudAlert Severity="Severity.Success" Class="mb-3">@T(TranslationKeys.BleTestSuccess)</MudAlert>
+    }
+    else
+    {
+        <MudAlert Severity="Severity.Warning" Class="mb-3">
+            <div>@GetResultMessage(_result.ResultType)</div>
+            @if (!string.IsNullOrEmpty(_result.ErrorDetails))
+            {
+                <MudText Typo="Typo.caption">@Format(TranslationKeys.BleTestDetails, _result.ErrorDetails)</MudText>
+            }
+        </MudAlert>
+    }
+}
+
+@if (!_isTesting && !_isPairing)
+{
+    <MudButton Variant="Variant.Filled"
+               Color="Color.Primary"
+               StartIcon="@Icons.Material.Filled.Refresh"
+               OnClick="RunTest">
+        @T(TranslationKeys.BleTestAgainButton)
+    </MudButton>
+}
+
+@if (_result != null && _result.ResultType != BleConnectionTestResultType.Success)
+{
+    <div class="mt-4 p-3 border rounded">
+        <MudText Typo="Typo.subtitle1" GutterBottom="true">@T(TranslationKeys.BleTestPairKeyTitle)</MudText>
+        <MudText Typo="Typo.body2" Class="mb-3">@T(TranslationKeys.BleTestPairKeyHint)</MudText>
+        @if (_isPairing)
+        {
+            <MudText Typo="Typo.body2" Class="mb-2">@T(TranslationKeys.BleTestPairing)</MudText>
+            <LoadingSpinnerComponent />
+        }
+        else
+        {
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       StartIcon="@Icons.Material.Filled.Key"
+                       OnClick="PairKey">
+                @T(TranslationKeys.BleTestPairKeyButton)
+            </MudButton>
+        }
+        @if (_pairKeySucceeded == true)
+        {
+            <MudAlert Severity="Severity.Success" Class="mt-3">@T(TranslationKeys.BleTestPairKeySuccess)</MudAlert>
+        }
+        else if (_pairKeySucceeded == false)
+        {
+            <MudAlert Severity="Severity.Error" Class="mt-3">@Format(TranslationKeys.BleTestPairKeyError, _pairKeyErrorMessage ?? string.Empty)</MudAlert>
+        }
+    </div>
+}
+
+@code {
+    [Parameter, EditorRequired]
+    public string? Vin { get; set; }
+
+    /// <summary>
+    /// Runs the test as soon as the component is shown. Used where the test is part of a guided flow, e.g. after
+    /// BLE was enabled for a car.
+    /// </summary>
+    [Parameter]
+    public bool AutoTest { get; set; }
+
+    private DtoBleConnectionTestResult? _result;
+    private bool _isTesting;
+    private bool _autoTestTriggered;
+
+    private bool _isPairing;
+    private bool? _pairKeySucceeded;
+    private string? _pairKeyErrorMessage;
+
+    private string T(string key) =>
+        TextLocalizer.Get<BleConnectionTestComponentLocalizationRegistry>(key, typeof(SharedComponentLocalizationRegistry))
+        ?? key;
+
+    private string Format(string key, params object?[] arguments) =>
+        string.Format(CultureInfo.CurrentCulture, T(key), arguments);
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await base.OnParametersSetAsync();
+        //Only test once per component instance, further tests are triggered by the user via the test again button.
+        if (AutoTest && !_autoTestTriggered && !string.IsNullOrEmpty(Vin))
+        {
+            _autoTestTriggered = true;
+            await RunTest();
+        }
+    }
+
+    private async Task RunTest()
+    {
+        if (string.IsNullOrEmpty(Vin))
+        {
+            return;
+        }
+        _isTesting = true;
+        _pairKeySucceeded = null;
+        //The test takes up to half a minute, so make sure the spinner is rendered before waiting for the result.
+        StateHasChanged();
+        _result = await CarSettingsService.TestBleConnection(Vin);
+        _isTesting = false;
+    }
+
+    private async Task PairKey()
+    {
+        if (string.IsNullOrEmpty(Vin))
+        {
+            return;
+        }
+        _isPairing = true;
+        StateHasChanged();
+        var result = await CarSettingsService.PairKey(Vin);
+        _isPairing = false;
+        _pairKeySucceeded = result?.Success;
+        _pairKeyErrorMessage = result?.CarErrorMessage ?? result?.ResultMessage;
+    }
+
+    private string GetResultMessage(BleConnectionTestResultType resultType)
+    {
+        return resultType switch
+        {
+            BleConnectionTestResultType.CarNotFound => T(TranslationKeys.BleTestCarNotFound),
+            BleConnectionTestResultType.CarAsleep => T(TranslationKeys.BleTestCarAsleep),
+            BleConnectionTestResultType.KeyNotPaired => T(TranslationKeys.BleTestKeyNotPaired),
+            BleConnectionTestResultType.ContainerProblem => T(TranslationKeys.BleTestContainerProblem),
+            _ => T(TranslationKeys.BleTestUnknown),
+        };
+    }
+}

--- a/TeslaSolarCharger/Client/Components/StartPage/FleetApiTestComponent.razor
+++ b/TeslaSolarCharger/Client/Components/StartPage/FleetApiTestComponent.razor
@@ -89,6 +89,13 @@ else if (_initialLoaded)
     [Parameter]
     public int? CarId { get; set; }
 
+    /// <summary>
+    /// Starts the connection test as soon as the state is loaded (unless the API access is known to work already).
+    /// Used where the test is part of a guided flow, e.g. when a car is set to be managed in the car dialog.
+    /// </summary>
+    [Parameter]
+    public bool AutoTest { get; set; }
+
     private TeslaCarFleetApiState? _fleetApiState;
 
     private string? _fleetApiStateErrorMessage;
@@ -98,6 +105,8 @@ else if (_initialLoaded)
     private bool _isTesting;
 
     private bool _initialLoaded;
+
+    private bool _autoTestTriggered;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -114,6 +123,12 @@ else if (_initialLoaded)
         _fleetApiStateErrorMessage = fleetApiState.ErrorMessage;
 
         _initialLoaded = true;
+        //Only test once per component instance, further tests are triggered by the user via the test again button.
+        if (AutoTest && !_autoTestTriggered && _fleetApiState != TeslaCarFleetApiState.Ok)
+        {
+            _autoTestTriggered = true;
+            await TestFleetApiAccess();
+        }
     }
 
     private async Task TestFleetApiAccess()
@@ -123,6 +138,8 @@ else if (_initialLoaded)
             return;
         }
         _isTesting = true;
+        //The test takes up to a minute, so make sure the spinner is rendered before waiting for the result.
+        StateHasChanged();
         var response = await HttpClient.GetFromJsonAsync<DtoValue<bool>>($"api/FleetApi/TestFleetApiAccess?carId={CarId}").ConfigureAwait(false);
         //Try again if non success because first try may result in no success because of Fleet API proxy required is only set after first error. So maybe the error is due to fleet Api proxy being required but not used.
         if (response!.Value == false)

--- a/TeslaSolarCharger/Client/Dialogs/CarEditDialog.razor
+++ b/TeslaSolarCharger/Client/Dialogs/CarEditDialog.razor
@@ -31,11 +31,22 @@
     </TitleContent>
     <DialogContent>
         <div style="max-height: 70vh; overflow-y: auto; overflow-x: hidden;">
-            @if (_showFleetApiTest)
+            @if (_showConnectionTests)
             {
-                <MudText Typo="Typo.subtitle1" GutterBottom="true">@T(TranslationKeys.CarEditFleetApiTestTitle)</MudText>
-                <MudText Typo="Typo.body2" Class="mb-3">@T(TranslationKeys.CarEditFleetApiTestHint)</MudText>
-                <FleetApiTestComponent CarId="Car.Item.Id" AutoTest="true" />
+                @if (_testFleetApiAccess)
+                {
+                    <MudText Typo="Typo.subtitle1" GutterBottom="true">@T(TranslationKeys.CarEditFleetApiTestTitle)</MudText>
+                    <MudText Typo="Typo.body2" Class="mb-3">@T(TranslationKeys.CarEditFleetApiTestHint)</MudText>
+                    <FleetApiTestComponent CarId="Car.Item.Id" AutoTest="true" />
+                }
+                @if (_testBleConnection)
+                {
+                    <div class="@(_testFleetApiAccess ? "mt-4" : "")">
+                        <MudText Typo="Typo.subtitle1" GutterBottom="true">@T(TranslationKeys.CarEditBleTestTitle)</MudText>
+                        <MudText Typo="Typo.body2" Class="mb-3">@T(TranslationKeys.CarEditBleTestHint)</MudText>
+                        <BleConnectionTestComponent Vin="Car.Item.Vin" AutoTest="true" />
+                    </div>
+                }
             }
             else
             {
@@ -119,6 +130,21 @@
                                         }
                                     </MudSelect>
                                 </div>
+                                @if (Car.Item.Id != default)
+                                {
+                                    @* The test runs against the saved configuration, so it saves the car first.
+                                       Without a car id there is nothing to save to, which only happens for a new
+                                       manual car - those are never Teslas and can not use BLE anyway. *@
+                                    <div class="px-2 pt-2">
+                                        <MudButton Variant="Variant.Filled"
+                                                   Color="Color.Primary"
+                                                   StartIcon="@Icons.Material.Filled.Bluetooth"
+                                                   OnClick="SaveAndTestBleConnection"
+                                                   Disabled="_isSaving">
+                                            @T(TranslationKeys.CarEditBleTestButton)
+                                        </MudButton>
+                                    </div>
+                                }
                             }
 
                             <div class="px-2 pt-2">
@@ -176,11 +202,11 @@
         </div>
     </DialogContent>
     <DialogActions>
-        @if (_showFleetApiTest)
+        @if (_showConnectionTests)
         {
-            @* The configuration is already saved at this point, so the test never blocks: the user can close the
-               dialog at any time and the car stays managed. *@
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="CloseAfterFleetApiTest">@T(TranslationKeys.GeneralClose)</MudButton>
+            @* The configuration is already saved at this point, so the tests never block: the user can close the
+               dialog at any time and the car stays configured. *@
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="CloseAfterConnectionTests">@T(TranslationKeys.GeneralClose)</MudButton>
         }
         else
         {
@@ -212,7 +238,21 @@
     /// </summary>
     private bool _wasManagedOnOpen;
     private TeslaCarFleetApiState? _fleetApiStateOnOpen;
-    private bool _showFleetApiTest;
+
+    /// <summary>
+    /// Whether BLE was already enabled when the dialog was opened. Only a car that gets BLE enabled needs the
+    /// connection test, as only then it is unknown whether TSC's key is added to the car.
+    /// </summary>
+    private bool _useBleOnOpen;
+
+    /// <summary>
+    /// Set when the user explicitly asked for a BLE test, so the test also runs for a car that already used BLE.
+    /// </summary>
+    private bool _bleTestRequested;
+
+    private bool _showConnectionTests;
+    private bool _testFleetApiAccess;
+    private bool _testBleConnection;
 
     private bool IsBleDataCollectionActive => _getVehicleDataViaBle && Car.Item.UseBle && !Car.Item.IncludeTrackingRelevantFields;
 
@@ -226,6 +266,7 @@
     protected override async Task OnInitializedAsync()
     {
         _wasManagedOnOpen = Car.Item.ShouldBeManaged;
+        _useBleOnOpen = Car.Item.UseBle;
         if (Car.Item.CarType == CarType.Tesla && Car.Item.Id != default)
         {
             var fleetApiStateResult = await HomeService.GetFleetApiState(Car.Item.Id);
@@ -330,7 +371,7 @@
 
     private void Cancel() => MudDialog.Cancel();
 
-    private void CloseAfterFleetApiTest() => MudDialog.Close(DialogResult.Ok(true));
+    private void CloseAfterConnectionTests() => MudDialog.Close(DialogResult.Ok(true));
 
     /// <summary>
     /// A Tesla that is switched to be managed needs a working Fleet API connection. Cars whose access is known to
@@ -341,6 +382,26 @@
                                              && Car.Item.ShouldBeManaged
                                              && !_wasManagedOnOpen
                                              && _fleetApiStateOnOpen != TeslaCarFleetApiState.Ok;
+
+    /// <summary>
+    /// BLE only works once TSC's key is added to the car, which nothing else checks. Test whenever BLE is switched
+    /// on and whenever the user asks for it.
+    /// </summary>
+    private bool ShouldTestBleConnection => Car.Item.CarType == CarType.Tesla
+                                            && Car.Item.Id != default
+                                            && Car.Item.UseBle
+                                            && !string.IsNullOrEmpty(Car.Item.Vin)
+                                            && (!_useBleOnOpen || _bleTestRequested);
+
+    /// <summary>
+    /// The connection test uses the car's saved BLE configuration, so unsaved changes (e.g. a just entered BLE url)
+    /// would be tested against the old values. Save first, then test.
+    /// </summary>
+    private async Task SaveAndTestBleConnection()
+    {
+        _bleTestRequested = true;
+        await Submit();
+    }
 
     private async Task Submit()
     {
@@ -357,12 +418,15 @@
 
         if (!result.HasError)
         {
-            if (ShouldTestFleetApiAccess)
+            //A car TSC is not registered in can not be controlled, neither via the Fleet API nor via BLE. Instead of
+            //letting the user find that out via the error box on the home page, run the tests right away and guide
+            //them through registering the key. The car is saved already, so this never blocks anything.
+            _testFleetApiAccess = ShouldTestFleetApiAccess;
+            _testBleConnection = ShouldTestBleConnection;
+            _bleTestRequested = false;
+            if (_testFleetApiAccess || _testBleConnection)
             {
-                //A car that is not registered in the Tesla account can not be controlled by TSC. Instead of letting
-                //the user find that out via the error box on the home page, run the test right away and guide them
-                //through registering the virtual key. The car is saved already, so this never blocks anything.
-                _showFleetApiTest = true;
+                _showConnectionTests = true;
                 return;
             }
             MudDialog.Close(DialogResult.Ok(true));

--- a/TeslaSolarCharger/Client/Dialogs/CarEditDialog.razor
+++ b/TeslaSolarCharger/Client/Dialogs/CarEditDialog.razor
@@ -1,6 +1,7 @@
 @using System.Globalization
 @using MudBlazor
 @using PkSoftwareService.Custom.Backend.Ble
+@using TeslaSolarCharger.Client.Components.StartPage
 @using TeslaSolarCharger.Client.Helper.Contracts
 @using TeslaSolarCharger.Client.Services.Contracts
 @using TeslaSolarCharger.Shared.Dtos
@@ -16,6 +17,7 @@
 @inject IConstants Constants
 @inject ISnackbar Snackbar
 @inject ICarSettingsService CarSettingsService
+@inject IHomeService HomeService
 @inject NavigationManager NavigationManager
 @inject IDialogService DialogService
 @inject IHttpClientHelper HttpClientHelper
@@ -29,6 +31,14 @@
     </TitleContent>
     <DialogContent>
         <div style="max-height: 70vh; overflow-y: auto; overflow-x: hidden;">
+            @if (_showFleetApiTest)
+            {
+                <MudText Typo="Typo.subtitle1" GutterBottom="true">@T(TranslationKeys.CarEditFleetApiTestTitle)</MudText>
+                <MudText Typo="Typo.body2" Class="mb-3">@T(TranslationKeys.CarEditFleetApiTestHint)</MudText>
+                <FleetApiTestComponent CarId="Car.Item.Id" AutoTest="true" />
+            }
+            else
+            {
             <EditFormComponent T="CarBasicConfiguration" WrappedElement="Car"
                                HideSubmitButton="true" @ref="_editForm">
                 
@@ -162,11 +172,21 @@
                     </div>
                 }
             </EditFormComponent>
+            }
         </div>
     </DialogContent>
     <DialogActions>
-        <MudButton OnClick="Cancel">@T(TranslationKeys.GeneralCancel)</MudButton>
-        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit" Disabled="_isSaving">@T(TranslationKeys.GeneralSave)</MudButton>
+        @if (_showFleetApiTest)
+        {
+            @* The configuration is already saved at this point, so the test never blocks: the user can close the
+               dialog at any time and the car stays managed. *@
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="CloseAfterFleetApiTest">@T(TranslationKeys.GeneralClose)</MudButton>
+        }
+        else
+        {
+            <MudButton OnClick="Cancel">@T(TranslationKeys.GeneralCancel)</MudButton>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Submit" Disabled="_isSaving">@T(TranslationKeys.GeneralSave)</MudButton>
+        }
     </DialogActions>
 </MudDialog>
 
@@ -186,6 +206,14 @@
     private List<DtoBleAdapter> _bleAdapters = new();
     private bool _isLoadingBleAdapters;
 
+    /// <summary>
+    /// Whether the car was already managed when the dialog was opened. Only a car that is switched to be managed
+    /// needs the Fleet API connection test, an already managed car has been through it before.
+    /// </summary>
+    private bool _wasManagedOnOpen;
+    private TeslaCarFleetApiState? _fleetApiStateOnOpen;
+    private bool _showFleetApiTest;
+
     private bool IsBleDataCollectionActive => _getVehicleDataViaBle && Car.Item.UseBle && !Car.Item.IncludeTrackingRelevantFields;
 
     private string T(string key) =>
@@ -197,6 +225,12 @@
 
     protected override async Task OnInitializedAsync()
     {
+        _wasManagedOnOpen = Car.Item.ShouldBeManaged;
+        if (Car.Item.CarType == CarType.Tesla && Car.Item.Id != default)
+        {
+            var fleetApiStateResult = await HomeService.GetFleetApiState(Car.Item.Id);
+            _fleetApiStateOnOpen = fleetApiStateResult.Data;
+        }
         var result = await HttpClientHelper.SendGetRequestAsync<DtoValue<bool>>("api/BaseConfiguration/GetVehicleDataViaBle");
         _getVehicleDataViaBle = !result.HasError && (result.Data?.Value == true);
         //Saving a car config while Get data via BLE is enabled switches the car to BLE data collection on the server,
@@ -296,6 +330,18 @@
 
     private void Cancel() => MudDialog.Cancel();
 
+    private void CloseAfterFleetApiTest() => MudDialog.Close(DialogResult.Ok(true));
+
+    /// <summary>
+    /// A Tesla that is switched to be managed needs a working Fleet API connection. Cars whose access is known to
+    /// work are not tested again, so no unnecessary wake up is triggered.
+    /// </summary>
+    private bool ShouldTestFleetApiAccess => Car.Item.CarType == CarType.Tesla
+                                             && Car.Item.Id != default
+                                             && Car.Item.ShouldBeManaged
+                                             && !_wasManagedOnOpen
+                                             && _fleetApiStateOnOpen != TeslaCarFleetApiState.Ok;
+
     private async Task Submit()
     {
         // Run client-side (FluentValidation) validation before hitting the server so invalid values are shown
@@ -311,6 +357,14 @@
 
         if (!result.HasError)
         {
+            if (ShouldTestFleetApiAccess)
+            {
+                //A car that is not registered in the Tesla account can not be controlled by TSC. Instead of letting
+                //the user find that out via the error box on the home page, run the test right away and guide them
+                //through registering the virtual key. The car is saved already, so this never blocks anything.
+                _showFleetApiTest = true;
+                return;
+            }
             MudDialog.Close(DialogResult.Ok(true));
             return;
         }

--- a/TeslaSolarCharger/Client/Services/CarSettingsService.cs
+++ b/TeslaSolarCharger/Client/Services/CarSettingsService.cs
@@ -77,6 +77,13 @@ public class CarSettingsService(ILogger<CarSettingsService> logger,
         return await httpClientHelper.SendGetRequestWithSnackbarAsync<DtoBleCommandResult>(url);
     }
 
+    public async Task<DtoBleConnectionTestResult?> TestBleConnection(string vin)
+    {
+        logger.LogTrace("{method}({vin})", nameof(TestBleConnection), vin);
+        var url = $"/api/Ble/TestConnection?vin={Uri.EscapeDataString(vin)}";
+        return await httpClientHelper.SendGetRequestWithSnackbarAsync<DtoBleConnectionTestResult>(url);
+    }
+
     public async Task<DtoBleCommandResult?> SetAmp(string vin, int amps)
     {
         logger.LogTrace("{method}({vin}, {amps})", nameof(SetAmp), vin, amps);

--- a/TeslaSolarCharger/Client/Services/Contracts/ICarSettingsService.cs
+++ b/TeslaSolarCharger/Client/Services/Contracts/ICarSettingsService.cs
@@ -15,6 +15,12 @@ public interface ICarSettingsService
     Task<DtoCarDeletionProgress?> GetCarDeletionProgress(int id);
     Task<TokenState?> GetFleetApiTokenState();
     Task<DtoBleCommandResult?> PairKey(string vin);
+
+    /// <summary>
+    /// Checks whether TSC can control the car via BLE. Uses the car's saved BLE configuration, so the car has to be
+    /// saved before testing.
+    /// </summary>
+    Task<DtoBleConnectionTestResult?> TestBleConnection(string vin);
     Task<DtoBleCommandResult?> SetAmp(string vin, int amps);
     Task<DtoBleCommandResult?> WakeUp(string vin);
     Task<bool> DisconnectCarFromSmartCar(int carId);

--- a/TeslaSolarCharger/Server/Controllers/BleController.cs
+++ b/TeslaSolarCharger/Server/Controllers/BleController.cs
@@ -48,6 +48,12 @@ public class BleController (IBleService bleService) : ApiBaseController
     [HttpGet]
     public Task<DtoBlePresenceResult> Presence(string vin) => bleService.GetPresenceForVin(vin);
 
+    /// <summary>
+    /// Checks whether TSC can control the car via BLE and, if not, what the user has to do about it.
+    /// </summary>
+    [HttpGet]
+    public Task<DtoBleConnectionTestResult> TestConnection(string vin) => bleService.TestConnection(vin);
+
     [HttpGet]
     public async Task<IActionResult> DownloadLogs(string bleApiBaseUrl)
     {

--- a/TeslaSolarCharger/Server/Services/Contracts/IBleService.cs
+++ b/TeslaSolarCharger/Server/Services/Contracts/IBleService.cs
@@ -25,6 +25,12 @@ public interface IBleService
     Task<DtoBleCommandResult> GetBodyControllerState(string vin);
 
     /// <summary>
+    /// Checks whether TSC can control the given car via BLE and, if it can not, why. Only asks for data, so a
+    /// sleeping car is not woken up: it is reported as asleep instead.
+    /// </summary>
+    Task<DtoBleConnectionTestResult> TestConnection(string vin);
+
+    /// <summary>
     /// Asks one container what it knows about the given cars: how long ago each was last heard, by advertisement or
     /// by a command it answered. Answered from the container's memory, so it never touches the radio, never wakes a
     /// car, and costs nothing at all for a car that is not there.

--- a/TeslaSolarCharger/Server/Services/TeslaBleService.cs
+++ b/TeslaSolarCharger/Server/Services/TeslaBleService.cs
@@ -3,6 +3,7 @@ using PkSoftwareService.Custom.Backend.Ble;
 using System.Net;
 using System.Web;
 using TeslaSolarCharger.Server.Dtos.Ble;
+using TeslaSolarCharger.Server.Helper;
 using TeslaSolarCharger.Server.Resources.PossibleIssues.Contracts;
 using TeslaSolarCharger.Server.Services.Contracts;
 using TeslaSolarCharger.Shared.Contracts;
@@ -11,6 +12,8 @@ using TeslaSolarCharger.Shared.Dtos.Ble;
 using TeslaSolarCharger.Shared.Dtos.Contracts;
 using TeslaSolarCharger.Shared.Enums;
 using TeslaSolarCharger.Shared.Resources;
+using VehicleSleepStatus = VCSEC.VehicleSleepStatus_E;
+using VehicleStatus = VCSEC.VehicleStatus;
 
 namespace TeslaSolarCharger.Server.Services;
 
@@ -94,6 +97,112 @@ public class TeslaBleService(ILogger<TeslaBleService> logger,
         };
         var result = await SendCommandToBle(request).ConfigureAwait(false);
         return result;
+    }
+
+    public async Task<DtoBleConnectionTestResult> TestConnection(string vin)
+    {
+        logger.LogTrace("{method}({vin})", nameof(TestConnection), vin);
+        //Reading the charge state needs everything BLE control needs: the car in range, a paired key and an awake
+        //infotainment system. Every failure is narrowed down afterwards so the user gets told what to do.
+        var chargeStateResult = await GetChargeState(vin).ConfigureAwait(false);
+        var errorDetails = chargeStateResult.CarErrorMessage ?? chargeStateResult.ResultMessage;
+        var chargeStateVerdict = ClassifyChargeState(chargeStateResult);
+        if (chargeStateVerdict != default)
+        {
+            return new DtoBleConnectionTestResult
+            {
+                ResultType = chargeStateVerdict.Value,
+                ErrorDetails = chargeStateVerdict == BleConnectionTestResultType.Success ? null : errorDetails,
+            };
+        }
+
+        //Presence is answered from the container's memory, so asking costs nothing and never wakes the car.
+        var presence = await GetPresenceForVin(vin).ConfigureAwait(false);
+        var presenceVerdict = ClassifyPresence(presence, vin);
+        if (presenceVerdict != default)
+        {
+            return new DtoBleConnectionTestResult
+            {
+                ResultType = presenceVerdict.Value,
+                ErrorDetails = string.IsNullOrEmpty(presence.ErrorMessage) ? errorDetails : presence.ErrorMessage,
+            };
+        }
+
+        //The car is there but the charge state could not be read. The body controller needs the key as well but no
+        //awake infotainment system, so it tells apart a missing key from a sleeping car.
+        var bodyControllerStateResult = await GetBodyControllerState(vin).ConfigureAwait(false);
+        var isAwake = BleProtoJson.TryParse<VehicleStatus>(bodyControllerStateResult.ResultMessage)?.VehicleSleepStatus
+                      == VehicleSleepStatus.VehicleSleepStatusAwake;
+        return new DtoBleConnectionTestResult
+        {
+            ResultType = ClassifyBodyControllerState(bodyControllerStateResult, isAwake),
+            ErrorDetails = bodyControllerStateResult.Success
+                ? errorDetails
+                : bodyControllerStateResult.CarErrorMessage ?? bodyControllerStateResult.ResultMessage ?? errorDetails,
+        };
+    }
+
+    /// <summary>
+    /// Result of the connection test as far as the charge state alone decides it. Null when the car has to be
+    /// narrowed down further, i.e. when it is unknown whether the car is there at all.
+    /// </summary>
+    internal static BleConnectionTestResultType? ClassifyChargeState(DtoBleCommandResult chargeStateResult)
+    {
+        if (chargeStateResult.Success)
+        {
+            return BleConnectionTestResultType.Success;
+        }
+        return chargeStateResult.Outcome switch
+        {
+            //The car answered the body controller, so it is in range and the key works. Only the infotainment
+            //system is asleep, which is not an error at all.
+            BleCommandOutcome.CarAsleep => BleConnectionTestResultType.CarAsleep,
+            //Local problems: the car was never asked, so nothing about it can be concluded.
+            BleCommandOutcome.AdapterNotFound => BleConnectionTestResultType.ContainerProblem,
+            BleCommandOutcome.AdapterUnavailable => BleConnectionTestResultType.ContainerProblem,
+            BleCommandOutcome.WorkerError => BleConnectionTestResultType.ContainerProblem,
+            BleCommandOutcome.WorkerTimeout => BleConnectionTestResultType.ContainerProblem,
+            BleCommandOutcome.InvalidRequest => BleConnectionTestResultType.ContainerProblem,
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Result of the connection test as far as the container's presence knowledge decides it. Null when the car is
+    /// present (or might be) and the reason for the failed command still has to be found.
+    /// </summary>
+    internal static BleConnectionTestResultType? ClassifyPresence(DtoBlePresenceResult presence, string vin)
+    {
+        if (!string.IsNullOrEmpty(presence.ErrorMessage) || !presence.ScannerRunning)
+        {
+            return BleConnectionTestResultType.ContainerProblem;
+        }
+        var vehicle = presence.Vehicles.FirstOrDefault(v => string.Equals(v.Vin, vin, StringComparison.OrdinalIgnoreCase));
+        if (vehicle?.Heard == true)
+        {
+            return null;
+        }
+        //While the scan is warming up nothing may be concluded from silence: not heard yet is not the same as not
+        //there, so the car is asked instead of being declared away.
+        return presence.WarmingUp ? null : BleConnectionTestResultType.CarNotFound;
+    }
+
+    /// <summary>
+    /// Final result for a car the container hears but whose charge state could not be read.
+    /// </summary>
+    internal static BleConnectionTestResultType ClassifyBodyControllerState(DtoBleCommandResult bodyControllerStateResult,
+        bool isAwake)
+    {
+        if (!bodyControllerStateResult.Success)
+        {
+            //A car that does not even answer its body controller either left in the meantime or, far more likely,
+            //never got TSC's key.
+            return bodyControllerStateResult.Outcome == BleCommandOutcome.CarAbsent
+                ? BleConnectionTestResultType.CarNotFound
+                : BleConnectionTestResultType.KeyNotPaired;
+        }
+        //The key works: either the car is asleep or something transient went wrong.
+        return isAwake ? BleConnectionTestResultType.Unknown : BleConnectionTestResultType.CarAsleep;
     }
 
     public async Task<DtoBleCommandResult> StopCharging(string vin)

--- a/TeslaSolarCharger/Shared/Dtos/Ble/DtoBleConnectionTestResult.cs
+++ b/TeslaSolarCharger/Shared/Dtos/Ble/DtoBleConnectionTestResult.cs
@@ -1,0 +1,37 @@
+namespace TeslaSolarCharger.Shared.Dtos.Ble;
+
+/// <summary>
+/// Why a BLE connection test did not work. Decided on the structured command outcome and, where that is not
+/// conclusive on its own, on the container's presence knowledge and a body controller probe.
+/// </summary>
+public enum BleConnectionTestResultType
+{
+    /// <summary>TSC could read the car's charge state, so everything needed for BLE control works.</summary>
+    Success,
+    /// <summary>The container did not hear the car, so it is either not at home or out of range of the antenna.</summary>
+    CarNotFound,
+    /// <summary>
+    /// The car is there and answers the body controller, but its infotainment system is asleep. Nothing is broken,
+    /// the car only has to be woken up.
+    /// </summary>
+    CarAsleep,
+    /// <summary>
+    /// The car is there but no secure connection can be established, which almost always means TSC's key was never
+    /// added to the car.
+    /// </summary>
+    KeyNotPaired,
+    /// <summary>The BLE container or its Bluetooth adapter could not be used, so the car was never asked at all.</summary>
+    ContainerProblem,
+    /// <summary>The car is there and the key works, but the request failed for another reason.</summary>
+    Unknown,
+}
+
+public class DtoBleConnectionTestResult
+{
+    public BleConnectionTestResultType ResultType { get; set; }
+
+    /// <summary>
+    /// The underlying error text of the failed request, shown to the user as additional detail. Never parsed.
+    /// </summary>
+    public string? ErrorDetails { get; set; }
+}

--- a/TeslaSolarCharger/Shared/Localization/Registries/Components/BleConnectionTestComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Components/BleConnectionTestComponentLocalizationRegistry.cs
@@ -1,0 +1,79 @@
+namespace TeslaSolarCharger.Shared.Localization.Registries.Components;
+
+public class BleConnectionTestComponentLocalizationRegistry : TextLocalizationRegistry<BleConnectionTestComponentLocalizationRegistry>
+{
+    protected override void Configure()
+    {
+        Register(TranslationKeys.BleTestTesting,
+            new TextLocalizationTranslation(LanguageCodes.English, "Testing the BLE connection can take up to 30 seconds..."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Das Testen der BLE-Verbindung kann bis zu 30 Sekunden dauern..."));
+
+        Register(TranslationKeys.BleTestSuccess,
+            new TextLocalizationTranslation(LanguageCodes.English, "BLE connection is working."),
+            new TextLocalizationTranslation(LanguageCodes.German, "BLE-Verbindung funktioniert."));
+
+        Register(TranslationKeys.BleTestCarNotFound,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "The BLE container did not hear the car. Make sure the car is parked within range of the container's antenna and test again."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Der BLE-Container hat das Fahrzeug nicht gehört. Stellen Sie sicher, dass das Fahrzeug in Reichweite der Antenne des Containers steht, und testen Sie erneut."));
+
+        Register(TranslationKeys.BleTestCarAsleep,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "The car is in range and TSC's key works, but the car is asleep. Open a door to wake it up and test again."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Das Fahrzeug ist in Reichweite und der Schlüssel von TSC funktioniert, aber das Fahrzeug schläft. Öffnen Sie eine Tür, um es aufzuwecken, und testen Sie erneut."));
+
+        Register(TranslationKeys.BleTestKeyNotPaired,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "The car is in range but TSC can not establish a secure connection to it. In almost all cases this means TSC's key is not added to the car yet."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Das Fahrzeug ist in Reichweite, aber TSC kann keine sichere Verbindung aufbauen. Fast immer bedeutet das, dass der Schlüssel von TSC noch nicht im Fahrzeug hinterlegt ist."));
+
+        Register(TranslationKeys.BleTestContainerProblem,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "The BLE container could not be reached or its Bluetooth adapter could not be used, so the car was never asked. Check the BLE URL, the selected adapter and the container's logs."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Der BLE-Container war nicht erreichbar oder sein Bluetooth-Adapter konnte nicht verwendet werden, das Fahrzeug wurde daher gar nicht angefragt. Prüfen Sie die BLE-URL, den ausgewählten Adapter und die Logs des Containers."));
+
+        Register(TranslationKeys.BleTestUnknown,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "The car is in range and TSC's key works, but the request failed. Please test again."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Das Fahrzeug ist in Reichweite und der Schlüssel von TSC funktioniert, die Anfrage ist aber fehlgeschlagen. Bitte testen Sie erneut."));
+
+        Register(TranslationKeys.BleTestAgainButton,
+            new TextLocalizationTranslation(LanguageCodes.English, "Test again"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Erneut testen"));
+
+        Register(TranslationKeys.BleTestDetails,
+            new TextLocalizationTranslation(LanguageCodes.English, "Details: {0}"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Details: {0}"));
+
+        Register(TranslationKeys.BleTestPairKeyTitle,
+            new TextLocalizationTranslation(LanguageCodes.English, "Add TSC's key to the car"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Schlüssel von TSC im Fahrzeug hinterlegen"));
+
+        Register(TranslationKeys.BleTestPairKeyHint,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Go to the car and wake it up, e.g. by opening a door. After clicking the button, confirm the new key within 30 seconds by holding one of your key cards against the center console."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Gehen Sie zum Fahrzeug und wecken Sie es auf, zum Beispiel durch das Öffnen einer Tür. Bestätigen Sie den neuen Schlüssel nach dem Klick auf die Schaltfläche innerhalb von 30 Sekunden, indem Sie eine Ihrer Schlüsselkarten an die Mittelkonsole halten."));
+
+        Register(TranslationKeys.BleTestPairKeyButton,
+            new TextLocalizationTranslation(LanguageCodes.English, "Add key"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Schlüssel hinzufügen"));
+
+        Register(TranslationKeys.BleTestPairing,
+            new TextLocalizationTranslation(LanguageCodes.English, "Waiting for the confirmation in the car..."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Warten auf die Bestätigung im Fahrzeug..."));
+
+        Register(TranslationKeys.BleTestPairKeySuccess,
+            new TextLocalizationTranslation(LanguageCodes.English, "The key was added. Test the connection again."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Der Schlüssel wurde hinzugefügt. Testen Sie die Verbindung erneut."));
+
+        Register(TranslationKeys.BleTestPairKeyError,
+            new TextLocalizationTranslation(LanguageCodes.English, "Could not add the key: {0}"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Der Schlüssel konnte nicht hinzugefügt werden: {0}"));
+    }
+}

--- a/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
@@ -435,5 +435,15 @@ public class CarSettingsPageLocalizationRegistry : TextLocalizationRegistry<CarS
         Register(TranslationKeys.CarEditTeslaSpecific,
             new TextLocalizationTranslation(LanguageCodes.English, "Tesla Specific"),
             new TextLocalizationTranslation(LanguageCodes.German, "Tesla-spezifisch"));
+
+        Register(TranslationKeys.CarEditFleetApiTestTitle,
+            new TextLocalizationTranslation(LanguageCodes.English, "Fleet API connection test"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Fleet-API-Verbindungstest"));
+
+        Register(TranslationKeys.CarEditFleetApiTestHint,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "The car was saved. As TSC can only control the car if it is registered in it, the connection is tested now. The car needs to be awake for the test, so open a door if it is asleep."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Das Fahrzeug wurde gespeichert. Da TSC das Fahrzeug nur steuern kann, wenn es dort registriert ist, wird die Verbindung jetzt getestet. Für den Test muss das Fahrzeug wach sein – öffnen Sie daher eine Tür, falls es schläft."));
     }
 }

--- a/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
@@ -445,5 +445,19 @@ public class CarSettingsPageLocalizationRegistry : TextLocalizationRegistry<CarS
                 "The car was saved. As TSC can only control the car if it is registered in it, the connection is tested now. The car needs to be awake for the test, so open a door if it is asleep."),
             new TextLocalizationTranslation(LanguageCodes.German,
                 "Das Fahrzeug wurde gespeichert. Da TSC das Fahrzeug nur steuern kann, wenn es dort registriert ist, wird die Verbindung jetzt getestet. Für den Test muss das Fahrzeug wach sein – öffnen Sie daher eine Tür, falls es schläft."));
+
+        Register(TranslationKeys.CarEditBleTestTitle,
+            new TextLocalizationTranslation(LanguageCodes.English, "Bluetooth connection test"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Bluetooth-Verbindungstest"));
+
+        Register(TranslationKeys.CarEditBleTestHint,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "TSC can only control the car via Bluetooth once its key is added to the car, so the connection is tested now. The car has to be parked in range of the BLE container."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "TSC kann das Fahrzeug per Bluetooth erst steuern, wenn sein Schlüssel im Fahrzeug hinterlegt ist. Daher wird die Verbindung jetzt getestet. Das Fahrzeug muss dafür in Reichweite des BLE-Containers stehen."));
+
+        Register(TranslationKeys.CarEditBleTestButton,
+            new TextLocalizationTranslation(LanguageCodes.English, "Save and test Bluetooth connection"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Speichern und Bluetooth-Verbindung testen"));
     }
 }

--- a/TeslaSolarCharger/Shared/Localization/Registries/SharedComponentLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/SharedComponentLocalizationRegistry.cs
@@ -34,6 +34,10 @@ public class SharedComponentLocalizationRegistry : TextLocalizationRegistry<Shar
             new TextLocalizationTranslation(LanguageCodes.English, "Cancel"),
             new TextLocalizationTranslation(LanguageCodes.German, "Abbrechen"));
 
+        Register(TranslationKeys.GeneralClose,
+            new TextLocalizationTranslation(LanguageCodes.English, "Close"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Schließen"));
+
         Register(TranslationKeys.GeneralProcessing,
             new TextLocalizationTranslation(LanguageCodes.English, "Processing"),
             new TextLocalizationTranslation(LanguageCodes.German, "Wird verarbeitet"));

--- a/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
+++ b/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
@@ -661,6 +661,7 @@ public static class TranslationKeys
 
     public static string GeneralSave => nameof(GeneralSave);
     public static string GeneralCancel => nameof(GeneralCancel);
+    public static string GeneralClose => nameof(GeneralClose);
     public static string GeneralProcessing => nameof(GeneralProcessing);
     public static string GeneralSaved => nameof(GeneralSaved);
     public static string GeneralLoading => nameof(GeneralLoading);
@@ -810,6 +811,8 @@ public static class TranslationKeys
 
     public static string CarEditManagementSettings => nameof(CarEditManagementSettings);
     public static string CarEditTeslaSpecific => nameof(CarEditTeslaSpecific);
+    public static string CarEditFleetApiTestTitle => nameof(CarEditFleetApiTestTitle);
+    public static string CarEditFleetApiTestHint => nameof(CarEditFleetApiTestHint);
 
     public static string ChargingStationOverviewConnectors => nameof(ChargingStationOverviewConnectors);
     public static string ChargingStationOverviewPhaseSwitching => nameof(ChargingStationOverviewPhaseSwitching);

--- a/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
+++ b/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
@@ -409,6 +409,22 @@ public static class TranslationKeys
     public static string FleetApiTestNotConfigured => nameof(FleetApiTestNotConfigured);
     public static string FleetApiTestRegisteredButNotTested => nameof(FleetApiTestRegisteredButNotTested);
 
+    public static string BleTestTesting => nameof(BleTestTesting);
+    public static string BleTestSuccess => nameof(BleTestSuccess);
+    public static string BleTestCarNotFound => nameof(BleTestCarNotFound);
+    public static string BleTestCarAsleep => nameof(BleTestCarAsleep);
+    public static string BleTestKeyNotPaired => nameof(BleTestKeyNotPaired);
+    public static string BleTestContainerProblem => nameof(BleTestContainerProblem);
+    public static string BleTestUnknown => nameof(BleTestUnknown);
+    public static string BleTestAgainButton => nameof(BleTestAgainButton);
+    public static string BleTestDetails => nameof(BleTestDetails);
+    public static string BleTestPairKeyTitle => nameof(BleTestPairKeyTitle);
+    public static string BleTestPairKeyHint => nameof(BleTestPairKeyHint);
+    public static string BleTestPairKeyButton => nameof(BleTestPairKeyButton);
+    public static string BleTestPairing => nameof(BleTestPairing);
+    public static string BleTestPairKeySuccess => nameof(BleTestPairKeySuccess);
+    public static string BleTestPairKeyError => nameof(BleTestPairKeyError);
+
     public static string HiddenErrorsTitle => nameof(HiddenErrorsTitle);
     public static string HiddenErrorsDescription => nameof(HiddenErrorsDescription);
     public static string HiddenErrorsUpdateHint => nameof(HiddenErrorsUpdateHint);
@@ -813,6 +829,9 @@ public static class TranslationKeys
     public static string CarEditTeslaSpecific => nameof(CarEditTeslaSpecific);
     public static string CarEditFleetApiTestTitle => nameof(CarEditFleetApiTestTitle);
     public static string CarEditFleetApiTestHint => nameof(CarEditFleetApiTestHint);
+    public static string CarEditBleTestTitle => nameof(CarEditBleTestTitle);
+    public static string CarEditBleTestHint => nameof(CarEditBleTestHint);
+    public static string CarEditBleTestButton => nameof(CarEditBleTestButton);
 
     public static string ChargingStationOverviewConnectors => nameof(ChargingStationOverviewConnectors);
     public static string ChargingStationOverviewPhaseSwitching => nameof(ChargingStationOverviewPhaseSwitching);

--- a/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ITextLocalizationRegistry, ChargingTargetConfigurationComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, EnergyPredictionComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, FleetApiTestComponentLocalizationRegistry>()
+            .AddSingleton<ITextLocalizationRegistry, BleConnectionTestComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, HiddenErrorsComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, LegendItemComponentLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, LoadpointComponentLocalizationRegistry>()


### PR DESCRIPTION
Fixes #2825

A Tesla can only be controlled once TSC is registered in it, but nothing checked that while the car was set up. The user only found out via the red box on the home page, long after leaving the dialog.

- Saving a Tesla that was switched to *should be managed* now switches the dialog to a Fleet API connection test step that runs the test right away.
- The existing `FleetApiTestComponent` from the home page is reused (new `AutoTest` parameter), so the guidance to register the virtual key and to test again exists exactly once.
- The car is saved **before** the test runs, so a failing test warns but never blocks the configuration - the user can close the dialog at any time.
- Cars whose Fleet API access is already known to work are not tested again, so no needless wake up is triggered.

Note: the test runs whenever the stored state is anything other than `Ok`, which also covers `NotWorking` and `OpenedLinkButNotTested`, not only cars that were never registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)