### PR TITLE
fix(localization): localize value configuration dropdown options

### DIFF
--- a/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Modbus/ModbusValueConfigurationDialog.razor
+++ b/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Modbus/ModbusValueConfigurationDialog.razor
@@ -14,7 +14,6 @@
 
 @inject HttpClient HttpClient
 @inject IConstants Constants
-@inject IStringHelper StringHelper
 @inject ISnackbar Snackbar
 @inject ITextLocalizationService TextLocalizer
 
@@ -44,7 +43,7 @@ else
                                    Margin="Constants.InputMargin">
                             @foreach (ModbusEndianess item in Enum.GetValues(typeof(ModbusEndianess)))
                             {
-                                <MudSelectItem T="ModbusEndianess" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                <MudSelectItem T="ModbusEndianess" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                             }
                         </MudSelect>
                     </div>
@@ -72,7 +71,7 @@ else
                                                        Margin="Constants.InputMargin">
                                                 @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
                                                 {
-                                                    <MudSelectItem T="ValueUsage" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                                    <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                 }
                                             </MudSelect>
                                         </div>
@@ -86,7 +85,7 @@ else
                                                        Margin="Constants.InputMargin">
                                                 @foreach (ModbusRegisterType item in Enum.GetValues(typeof(ModbusRegisterType)))
                                                 {
-                                                    <MudSelectItem T="ModbusRegisterType" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                                    <MudSelectItem T="ModbusRegisterType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                 }
                                             </MudSelect>
                                         </div>
@@ -100,7 +99,7 @@ else
                                                        Margin="Constants.InputMargin">
                                                 @foreach (ModbusValueType item in Enum.GetValues(typeof(ModbusValueType)))
                                                 {
-                                                    <MudSelectItem T="ModbusValueType" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                                    <MudSelectItem T="ModbusValueType" Value="@item">@ValueConfigurationEnumNames.Get(item)</MudSelectItem>
                                                 }
                                             </MudSelect>
                                         </div>
@@ -126,7 +125,7 @@ else
                                                                Margin="Constants.InputMargin">
                                                         @foreach (ValueOperator item in Enum.GetValues(typeof(ValueOperator)))
                                                         {
-                                                            <MudSelectItem T="ValueOperator" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                                            <MudSelectItem T="ValueOperator" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                         }
                                                     </MudSelect>
                                                 </div>

--- a/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Mqtt/MqttValueConfigurationDialog.razor
+++ b/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Mqtt/MqttValueConfigurationDialog.razor
@@ -13,7 +13,6 @@
 
 @inject HttpClient HttpClient
 @inject IConstants Constants
-@inject IStringHelper StringHelper
 @inject ISnackbar Snackbar
 @inject ITextLocalizationService TextLocalizer
 
@@ -69,7 +68,7 @@ else
                                                        Margin="Constants.InputMargin">
                                                 @foreach (NodePatternType item in Enum.GetValues(typeof(NodePatternType)))
                                                 {
-                                                    <MudSelectItem T="NodePatternType" Value="@item">@GetNodePatternTypeName(item)</MudSelectItem>
+                                                    <MudSelectItem T="NodePatternType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                 }
                                             </MudSelect>
                                         </div>
@@ -82,7 +81,7 @@ else
                                                        Margin="Constants.InputMargin">
                                                 @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
                                                 {
-                                                    <MudSelectItem T="ValueUsage" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                                    <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                 }
                                             </MudSelect>
                                         </div>
@@ -124,7 +123,7 @@ else
                                                                Margin="Constants.InputMargin">
                                                         @foreach (ValueOperator item in Enum.GetValues(typeof(ValueOperator)))
                                                         {
-                                                            <MudSelectItem T="ValueOperator" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                                            <MudSelectItem T="ValueOperator" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                         }
                                                     </MudSelect>
                                                 </div>
@@ -318,14 +317,4 @@ else
         TextLocalizer.Get<ValueSourceConfigurationLocalizationRegistry>(key)
         ?? key;
 
-    private string GetNodePatternTypeName(NodePatternType nodePatternType)
-    {
-        return nodePatternType switch
-        {
-            NodePatternType.Direct => T(TranslationKeys.ValueSourceConfigNodePatternTypeDirect),
-            NodePatternType.Json => T(TranslationKeys.ValueSourceConfigNodePatternTypeJson),
-            NodePatternType.Xml => T(TranslationKeys.ValueSourceConfigNodePatternTypeXml),
-            _ => nodePatternType.ToString(),
-        };
-    }
 }

--- a/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Rest/RestValueConfigurationDialog.razor
+++ b/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Rest/RestValueConfigurationDialog.razor
@@ -13,7 +13,6 @@
 
 @inject HttpClient HttpClient
 @inject IConstants Constants
-@inject IStringHelper StringHelper
 @inject ISnackbar Snackbar
 @inject ITextLocalizationService TextLocalizer
 
@@ -41,7 +40,7 @@ else
                                    Margin="Constants.InputMargin">
                             @foreach (HttpVerb item in Enum.GetValues(typeof(HttpVerb)))
                             {
-                                <MudSelectItem T="HttpVerb" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                <MudSelectItem T="HttpVerb" Value="@item">@ValueConfigurationEnumNames.Get(item)</MudSelectItem>
                             }
                         </MudSelect>
                     </div>
@@ -128,7 +127,7 @@ else
                                    Margin="Constants.InputMargin">
                             @foreach (NodePatternType item in Enum.GetValues(typeof(NodePatternType)))
                             {
-                                <MudSelectItem T="NodePatternType" Value="@item">@GetNodePatternTypeName(item)</MudSelectItem>
+                                <MudSelectItem T="NodePatternType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                             }
                         </MudSelect>
                     </div>
@@ -151,7 +150,7 @@ else
                                                        Margin="Constants.InputMargin">
                                                 @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
                                                 {
-                                                    <MudSelectItem T="ValueUsage" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                                    <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                 }
                                             </MudSelect>
                                         </div>
@@ -193,7 +192,7 @@ else
                                                                Margin="Constants.InputMargin">
                                                         @foreach (ValueOperator item in Enum.GetValues(typeof(ValueOperator)))
                                                         {
-                                                            <MudSelectItem T="ValueOperator" Value="@item">@StringHelper.GenerateFriendlyStringFromPascalString(item.ToString())</MudSelectItem>
+                                                            <MudSelectItem T="ValueOperator" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                         }
                                                     </MudSelect>
                                                 </div>
@@ -422,14 +421,4 @@ else
         TextLocalizer.Get<ValueSourceConfigurationLocalizationRegistry>(key)
         ?? key;
 
-    private string GetNodePatternTypeName(NodePatternType nodePatternType)
-    {
-        return nodePatternType switch
-        {
-            NodePatternType.Direct => T(TranslationKeys.ValueSourceConfigNodePatternTypeDirect),
-            NodePatternType.Json => T(TranslationKeys.ValueSourceConfigNodePatternTypeJson),
-            NodePatternType.Xml => T(TranslationKeys.ValueSourceConfigNodePatternTypeXml),
-            _ => nodePatternType.ToString(),
-        };
-    }
 }

--- a/TeslaSolarCharger/Shared/Localization/Registries/Components/ValueSourceConfigurationLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Components/ValueSourceConfigurationLocalizationRegistry.cs
@@ -88,6 +88,46 @@ public class ValueSourceConfigurationLocalizationRegistry : TextLocalizationRegi
             new TextLocalizationTranslation(LanguageCodes.English, "Used for"),
             new TextLocalizationTranslation(LanguageCodes.German, "Verwendet für"));
 
+        Register(TranslationKeys.ValueUsageInverterPower,
+            new TextLocalizationTranslation(LanguageCodes.English, "Inverter power"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Wechselrichterleistung"));
+
+        Register(TranslationKeys.ValueUsageGridPower,
+            new TextLocalizationTranslation(LanguageCodes.English, "Grid power"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Netzleistung"));
+
+        Register(TranslationKeys.ValueUsageHomeBatteryPower,
+            new TextLocalizationTranslation(LanguageCodes.English, "Home battery power"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Heimspeicherleistung"));
+
+        Register(TranslationKeys.ValueUsageHomeBatterySoc,
+            new TextLocalizationTranslation(LanguageCodes.English, "Home battery SoC"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Heimspeicher-Ladezustand"));
+
+        Register(TranslationKeys.ValueOperatorPlus,
+            new TextLocalizationTranslation(LanguageCodes.English, "Plus"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Plus"));
+
+        Register(TranslationKeys.ValueOperatorMinus,
+            new TextLocalizationTranslation(LanguageCodes.English, "Minus"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Minus"));
+
+        Register(TranslationKeys.ModbusRegisterTypeHolding,
+            new TextLocalizationTranslation(LanguageCodes.English, "Holding register"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Holding-Register"));
+
+        Register(TranslationKeys.ModbusRegisterTypeInput,
+            new TextLocalizationTranslation(LanguageCodes.English, "Input register"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Input-Register"));
+
+        Register(TranslationKeys.ModbusEndianessBig,
+            new TextLocalizationTranslation(LanguageCodes.English, "Big endian"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Big Endian"));
+
+        Register(TranslationKeys.ModbusEndianessLittle,
+            new TextLocalizationTranslation(LanguageCodes.English, "Little endian"),
+            new TextLocalizationTranslation(LanguageCodes.German, "Little Endian"));
+
         Register(TranslationKeys.ValueSourceConfigOperator,
             new TextLocalizationTranslation(LanguageCodes.English, "Operator"),
             new TextLocalizationTranslation(LanguageCodes.German, "Operator"));

--- a/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
+++ b/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
@@ -354,6 +354,20 @@ public static class TranslationKeys
     public static string ValueSourceConfigHttpMethod => nameof(ValueSourceConfigHttpMethod);
     public static string ValueSourceConfigType => nameof(ValueSourceConfigType);
 
+    public static string ValueUsageInverterPower => nameof(ValueUsageInverterPower);
+    public static string ValueUsageGridPower => nameof(ValueUsageGridPower);
+    public static string ValueUsageHomeBatteryPower => nameof(ValueUsageHomeBatteryPower);
+    public static string ValueUsageHomeBatterySoc => nameof(ValueUsageHomeBatterySoc);
+
+    public static string ValueOperatorPlus => nameof(ValueOperatorPlus);
+    public static string ValueOperatorMinus => nameof(ValueOperatorMinus);
+
+    public static string ModbusRegisterTypeHolding => nameof(ModbusRegisterTypeHolding);
+    public static string ModbusRegisterTypeInput => nameof(ModbusRegisterTypeInput);
+
+    public static string ModbusEndianessBig => nameof(ModbusEndianessBig);
+    public static string ModbusEndianessLittle => nameof(ModbusEndianessLittle);
+
     public static string ValueSourceConfigFormNull => nameof(ValueSourceConfigFormNull);
     public static string ValueSourceConfigConfigNull => nameof(ValueSourceConfigConfigNull);
     public static string ValueSourceConfigConfigInvalid => nameof(ValueSourceConfigConfigInvalid);

--- a/TeslaSolarCharger/Shared/Localization/ValueConfigurationEnumNames.cs
+++ b/TeslaSolarCharger/Shared/Localization/ValueConfigurationEnumNames.cs
@@ -1,0 +1,75 @@
+using TeslaSolarCharger.Shared.Enums;
+using TeslaSolarCharger.Shared.Localization.Contracts;
+using TeslaSolarCharger.Shared.Localization.Registries;
+using TeslaSolarCharger.Shared.Localization.Registries.Components;
+using TeslaSolarCharger.SharedModel.Enums;
+
+namespace TeslaSolarCharger.Shared.Localization;
+
+/// <summary>
+/// Display names of the options offered in the value source configuration dialogs. Without these the dropdowns are
+/// rendered from the enum member names, which are never translated and read like code (e.g. "Home Battery Soc" or
+/// "Ulong"). Kept in one place because the same enums are offered in the REST, MQTT and Modbus dialogs.
+/// </summary>
+public static class ValueConfigurationEnumNames
+{
+    public static string Get(ITextLocalizationService localizer, ValueUsage valueUsage) => valueUsage switch
+    {
+        ValueUsage.InverterPower => T(localizer, TranslationKeys.ValueUsageInverterPower),
+        ValueUsage.GridPower => T(localizer, TranslationKeys.ValueUsageGridPower),
+        ValueUsage.HomeBatteryPower => T(localizer, TranslationKeys.ValueUsageHomeBatteryPower),
+        ValueUsage.HomeBatterySoc => T(localizer, TranslationKeys.ValueUsageHomeBatterySoc),
+        _ => valueUsage.ToString(),
+    };
+
+    public static string Get(ITextLocalizationService localizer, ValueOperator valueOperator) => valueOperator switch
+    {
+        ValueOperator.Plus => T(localizer, TranslationKeys.ValueOperatorPlus),
+        ValueOperator.Minus => T(localizer, TranslationKeys.ValueOperatorMinus),
+        _ => valueOperator.ToString(),
+    };
+
+    public static string Get(ITextLocalizationService localizer, NodePatternType nodePatternType) => nodePatternType switch
+    {
+        NodePatternType.Direct => T(localizer, TranslationKeys.ValueSourceConfigNodePatternTypeDirect),
+        NodePatternType.Json => T(localizer, TranslationKeys.ValueSourceConfigNodePatternTypeJson),
+        NodePatternType.Xml => T(localizer, TranslationKeys.ValueSourceConfigNodePatternTypeXml),
+        _ => nodePatternType.ToString(),
+    };
+
+    public static string Get(ITextLocalizationService localizer, ModbusRegisterType registerType) => registerType switch
+    {
+        ModbusRegisterType.HoldingRegister => T(localizer, TranslationKeys.ModbusRegisterTypeHolding),
+        ModbusRegisterType.InputRegister => T(localizer, TranslationKeys.ModbusRegisterTypeInput),
+        _ => registerType.ToString(),
+    };
+
+    public static string Get(ITextLocalizationService localizer, ModbusEndianess endianess) => endianess switch
+    {
+        ModbusEndianess.BigEndian => T(localizer, TranslationKeys.ModbusEndianessBig),
+        ModbusEndianess.LittleEndian => T(localizer, TranslationKeys.ModbusEndianessLittle),
+        _ => endianess.ToString(),
+    };
+
+    /// <summary>
+    /// Data type names are the same in every language, but the enum member names hide the width the user has to
+    /// match against their device's register map, so they are spelled out.
+    /// </summary>
+    public static string Get(ModbusValueType valueType) => valueType switch
+    {
+        ModbusValueType.Int => "Int 32",
+        ModbusValueType.UInt => "UInt 32",
+        ModbusValueType.Short => "Int 16",
+        ModbusValueType.UShort => "UInt 16",
+        ModbusValueType.Ulong => "UInt 64",
+        ModbusValueType.Float => "Float",
+        ModbusValueType.Bool => "Bool",
+        _ => valueType.ToString(),
+    };
+
+    /// <summary>HTTP method names are protocol tokens, so they are not translated but spelled as in the protocol.</summary>
+    public static string Get(HttpVerb httpVerb) => httpVerb.ToString().ToUpperInvariant();
+
+    private static string T(ITextLocalizationService localizer, string key) =>
+        localizer.Get<ValueSourceConfigurationLocalizationRegistry>(key) ?? key;
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #2851 (`fix/2807-node-pattern-type-wording`), which localized the first of these dropdowns and whose option keys this builds on. Merge #2851 first; the base switches to `develop` automatically afterwards.

Follow-up to #2807. The options of every dropdown in the REST, MQTT and Modbus value configuration dialogs were rendered from the enum member names, so they stayed English in every language and read like code.

| Enum | before | English | German |
|---|---|---|---|
| `ValueUsage` | Inverter Power | Inverter power | Wechselrichterleistung |
| | Grid Power | Grid power | Netzleistung |
| | Home Battery Power | Home battery power | Heimspeicherleistung |
| | Home Battery Soc | Home battery SoC | Heimspeicher-Ladezustand |
| `ValueOperator` | Plus / Minus | Plus / Minus | Plus / Minus |
| `ModbusRegisterType` | Holding Register | Holding register | Holding-Register |
| | Input Register | Input register | Input-Register |
| `ModbusEndianess` | Big Endian | Big endian | Big Endian |
| | Little Endian | Little endian | Little Endian |

Data type and protocol names are the same in every language and are therefore not translated, but they are spelled properly: `ModbusValueType` shows the width that has to be matched against the device's register map (`Int` → **Int 32**, `UShort` → **UInt 16**, `Ulong` → **UInt 64**, …) and `HttpVerb` shows **GET**.

The mapping lives in one place (`ValueConfigurationEnumNames`), since the same enums are offered in three dialogs - this also replaces the two copies of the node pattern type mapping added in #2807.

**Not included:** `TemplateValueGatherType` (the template picker) is a list of ~75 vendor and product names (`SmaHybridInverterModbus`, `FoxEssH3SmartModbus`, …). Those are proper nouns, so translating them would add 150 near-identical entries plus one more for every new template. Say the word if you want them anyway.

`RestValueResultConfigurationComponent.razor` also renders two of these enums, but it is not referenced anywhere, so it was left alone - it is a candidate for the dead component cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)