### PR TITLE
fix(cars): inline spinner while importing Teslas

### DIFF
--- a/TeslaSolarCharger/Client/Dialogs/AddCarDialog.razor
+++ b/TeslaSolarCharger/Client/Dialogs/AddCarDialog.razor
@@ -47,8 +47,10 @@
             {
                 @if (_isAddingTeslas)
                 {
-                    <MudText Typo="Typo.body2" Class="mb-3">@T(TranslationKeys.CarSettingsAddTeslaFromAccountLoading)</MudText>
-                    <LoadingSpinnerComponent />
+                    <div class="d-flex align-center mb-3">
+                        <MudProgressCircular Color="Color.Primary" Size="Size.Small" Indeterminate="true" Class="me-3 flex-none" />
+                        <MudText Typo="Typo.body2">@T(TranslationKeys.CarSettingsAddTeslaFromAccountLoading)</MudText>
+                    </div>
                 }
                 else if (_addedTeslasCount != null)
                 {

--- a/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Pages/CarSettingsPageLocalizationRegistry.cs
@@ -229,8 +229,8 @@ public class CarSettingsPageLocalizationRegistry : TextLocalizationRegistry<CarS
             new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeuge aus Tesla-Konto hinzufügen"));
 
         Register(TranslationKeys.CarSettingsAddTeslaFromAccountLoading,
-            new TextLocalizationTranslation(LanguageCodes.English, "Loading cars from your Tesla account. This can take a few seconds."),
-            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeuge werden aus Ihrem Tesla-Konto geladen. Das kann einige Sekunden dauern."));
+            new TextLocalizationTranslation(LanguageCodes.English, "Loading cars from your Tesla account. This can take a few minutes."),
+            new TextLocalizationTranslation(LanguageCodes.German, "Fahrzeuge werden aus Ihrem Tesla-Konto geladen. Das kann einige Minuten dauern."));
 
         Register(TranslationKeys.CarSettingsAddTeslaFromAccountNoNewCars,
             new TextLocalizationTranslation(LanguageCodes.English, "No new cars found in your Tesla account."),


### PR DESCRIPTION
Follow-up to #2852.

The full width loading spinner sat below the text, off center and far too big for a dialog. It is now a small MudBlazor progress circle in front of the text.

Importing takes minutes rather than seconds in practice, so the text says "This can take a few minutes." / "Das kann einige Minuten dauern."

🤖 Generated with [Claude Code](https://claude.com/claude-code)