### PR TITLE
feat(valueConfig): explain every value configuration input

### DIFF
--- a/TeslaSolarCharger.Tests/Services/Shared/ValueConfigurationInfoLocalizationTests.cs
+++ b/TeslaSolarCharger.Tests/Services/Shared/ValueConfigurationInfoLocalizationTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using TeslaSolarCharger.Shared.Localization;
+using TeslaSolarCharger.Shared.Localization.Registries.Components;
+using Xunit;
+
+namespace TeslaSolarCharger.Tests.Services.Shared;
+
+/// <summary>
+/// A missing registration is invisible in the UI: the dialog simply shows the key name. As the explanations are
+/// keys and content in two places, guard that every info key actually resolves in both languages.
+/// </summary>
+public class ValueConfigurationInfoLocalizationTests : TestBase
+{
+    public ValueConfigurationInfoLocalizationTests(ITestOutputHelper outputHelper)
+        : base(outputHelper)
+    {
+    }
+
+    public static TheoryData<string> InfoKeys()
+    {
+        var data = new TheoryData<string>();
+        foreach (var key in GetInfoKeys())
+        {
+            data.Add(key);
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(InfoKeys))]
+    public void EveryInfoTextIsRegisteredInEveryLanguage(string key)
+    {
+        var registry = new ValueConfigurationInfoLocalizationRegistry();
+
+        foreach (var language in new[] { LanguageCodes.English, LanguageCodes.German, })
+        {
+            var text = registry.Get(key, new CultureInfo(language));
+            Assert.False(string.IsNullOrWhiteSpace(text), $"{key} is not registered for {language}");
+        }
+    }
+
+    [Fact]
+    public void InfoKeysExist()
+    {
+        //Guards the test above: if the keys were renamed to another prefix it would silently test nothing.
+        Assert.NotEmpty(GetInfoKeys());
+    }
+
+    private static IEnumerable<string> GetInfoKeys() => typeof(TranslationKeys)
+        .GetProperties(BindingFlags.Public | BindingFlags.Static)
+        .Where(p => p.Name.StartsWith("ValueConfigInfo") && p.PropertyType == typeof(string))
+        .Select(p => (string)p.GetValue(null)!)
+        .ToList();
+}

--- a/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Modbus/ModbusValueConfigurationDialog.razor
+++ b/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Modbus/ModbusValueConfigurationDialog.razor
@@ -30,25 +30,34 @@ else
         <ChildContent>
             <MudDialog>
                 <DialogContent>
-                    <GenericInput For="() => EditableValueConfiguration.Item.UnitIdentifier"></GenericInput>
-                    <GenericInput For="() => EditableValueConfiguration.Item.Host"></GenericInput>
-                    <GenericInput For="() => EditableValueConfiguration.Item.Port"></GenericInput>
-                    <div class="px-2 pt-2">
-                        <MudSelect T="ModbusEndianess"
-                                   Class="@Constants.DefaultMargin"
-                                   Variant="Variant.Outlined"
-                                   Value="@EditableValueConfiguration.Item.Endianess"
-                                   ValueChanged="(newItem) => UpdateEndianess(EditableValueConfiguration.Item, newItem)"
-                                   Label="@T(TranslationKeys.ValueSourceConfigEndianess)"
-                                   Margin="Constants.InputMargin">
-                            @foreach (ModbusEndianess item in Enum.GetValues(typeof(ModbusEndianess)))
-                            {
-                                <MudSelectItem T="ModbusEndianess" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                            }
-                        </MudSelect>
+                    <GenericInput For="() => EditableValueConfiguration.Item.UnitIdentifier"
+                                  InfoText="@T(TranslationKeys.ValueConfigInfoUnitIdentifier)"></GenericInput>
+                    <GenericInput For="() => EditableValueConfiguration.Item.Host"
+                                  InfoText="@T(TranslationKeys.ValueConfigInfoModbusHost)"></GenericInput>
+                    <GenericInput For="() => EditableValueConfiguration.Item.Port"
+                                  InfoText="@T(TranslationKeys.ValueConfigInfoModbusPort)"></GenericInput>
+                    <div class="px-2 pt-2 d-flex align-center">
+                        <div class="flex-grow-1">
+                            <MudSelect T="ModbusEndianess"
+                                       Class="@Constants.DefaultMargin"
+                                       Variant="Variant.Outlined"
+                                       Value="@EditableValueConfiguration.Item.Endianess"
+                                       ValueChanged="(newItem) => UpdateEndianess(EditableValueConfiguration.Item, newItem)"
+                                       Label="@T(TranslationKeys.ValueSourceConfigEndianess)"
+                                       Margin="Constants.InputMargin">
+                                @foreach (ModbusEndianess item in Enum.GetValues(typeof(ModbusEndianess)))
+                                {
+                                    <MudSelectItem T="ModbusEndianess" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                }
+                            </MudSelect>
+                        </div>
+                        <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigEndianess)"
+                                             Text="@T(TranslationKeys.ValueConfigInfoEndianess)" />
                     </div>
-                    <GenericInput For="() => EditableValueConfiguration.Item.ConnectDelayMilliseconds"></GenericInput>
-                    <GenericInput For="() => EditableValueConfiguration.Item.ReadTimeoutMilliseconds"></GenericInput>
+                    <GenericInput For="() => EditableValueConfiguration.Item.ConnectDelayMilliseconds"
+                                  InfoText="@T(TranslationKeys.ValueConfigInfoConnectDelay)"></GenericInput>
+                    <GenericInput For="() => EditableValueConfiguration.Item.ReadTimeoutMilliseconds"
+                                  InfoText="@T(TranslationKeys.ValueConfigInfoReadTimeout)"></GenericInput>
                     @foreach (var editableResultConfig in EditableResultConfigurations)
                     {
                         <EditFormComponent T="DtoModbusValueResultConfiguration"
@@ -62,52 +71,67 @@ else
                                         {
                                             <GenericInput For="() => editableResultConfig.Item.Id" IsDisabledParameter="true"></GenericInput>
                                         }
-                                        <div class="p-2">
-                                            <MudSelect T="ValueUsage"
-                                                       Class="@Constants.DefaultMargin"
-                                                       Variant="Variant.Outlined"
-                                                       @bind-Value="@editableResultConfig.Item.UsedFor"
-                                                       Label="@T(TranslationKeys.ValueSourceConfigUsedFor)"
-                                                       Margin="Constants.InputMargin">
-                                                @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
-                                                {
-                                                    <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                                                }
-                                            </MudSelect>
+                                        <div class="p-2 d-flex align-center">
+                                            <div class="flex-grow-1">
+                                                <MudSelect T="ValueUsage"
+                                                           Class="@Constants.DefaultMargin"
+                                                           Variant="Variant.Outlined"
+                                                           @bind-Value="@editableResultConfig.Item.UsedFor"
+                                                           Label="@T(TranslationKeys.ValueSourceConfigUsedFor)"
+                                                           Margin="Constants.InputMargin">
+                                                    @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
+                                                    {
+                                                        <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                                    }
+                                                </MudSelect>
+                                            </div>
+                                            <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigUsedFor)"
+                                                                 Text="@T(TranslationKeys.ValueConfigInfoUsedFor)" />
                                         </div>
-                                        <div class="px-2 pt-2">
-                                            <MudSelect T="ModbusRegisterType"
-                                                       Class="@Constants.DefaultMargin"
-                                                       Variant="Variant.Outlined"
-                                                       Value="@editableResultConfig.Item.RegisterType"
-                                                       ValueChanged="(newItem) => UpdateRegisterType(editableResultConfig.Item, newItem)"
-                                                       Label="@T(TranslationKeys.ValueSourceConfigRegisterType)"
-                                                       Margin="Constants.InputMargin">
-                                                @foreach (ModbusRegisterType item in Enum.GetValues(typeof(ModbusRegisterType)))
-                                                {
-                                                    <MudSelectItem T="ModbusRegisterType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                                                }
-                                            </MudSelect>
+                                        <div class="px-2 pt-2 d-flex align-center">
+                                            <div class="flex-grow-1">
+                                                <MudSelect T="ModbusRegisterType"
+                                                           Class="@Constants.DefaultMargin"
+                                                           Variant="Variant.Outlined"
+                                                           Value="@editableResultConfig.Item.RegisterType"
+                                                           ValueChanged="(newItem) => UpdateRegisterType(editableResultConfig.Item, newItem)"
+                                                           Label="@T(TranslationKeys.ValueSourceConfigRegisterType)"
+                                                           Margin="Constants.InputMargin">
+                                                    @foreach (ModbusRegisterType item in Enum.GetValues(typeof(ModbusRegisterType)))
+                                                    {
+                                                        <MudSelectItem T="ModbusRegisterType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                                    }
+                                                </MudSelect>
+                                            </div>
+                                            <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigRegisterType)"
+                                                                 Text="@T(TranslationKeys.ValueConfigInfoRegisterType)" />
                                         </div>
-                                        <div class="px-2 pt-2">
-                                            <MudSelect T="ModbusValueType"
-                                                       Class="@Constants.DefaultMargin"
-                                                       Variant="Variant.Outlined"
-                                                       Value="@editableResultConfig.Item.ValueType"
-                                                       ValueChanged="(newItem) => UpdateValueType(editableResultConfig.Item, newItem)"
-                                                       Label="@T(TranslationKeys.ValueSourceConfigValueType)"
-                                                       Margin="Constants.InputMargin">
-                                                @foreach (ModbusValueType item in Enum.GetValues(typeof(ModbusValueType)))
-                                                {
-                                                    <MudSelectItem T="ModbusValueType" Value="@item">@ValueConfigurationEnumNames.Get(item)</MudSelectItem>
-                                                }
-                                            </MudSelect>
+                                        <div class="px-2 pt-2 d-flex align-center">
+                                            <div class="flex-grow-1">
+                                                <MudSelect T="ModbusValueType"
+                                                           Class="@Constants.DefaultMargin"
+                                                           Variant="Variant.Outlined"
+                                                           Value="@editableResultConfig.Item.ValueType"
+                                                           ValueChanged="(newItem) => UpdateValueType(editableResultConfig.Item, newItem)"
+                                                           Label="@T(TranslationKeys.ValueSourceConfigValueType)"
+                                                           Margin="Constants.InputMargin">
+                                                    @foreach (ModbusValueType item in Enum.GetValues(typeof(ModbusValueType)))
+                                                    {
+                                                        <MudSelectItem T="ModbusValueType" Value="@item">@ValueConfigurationEnumNames.Get(item)</MudSelectItem>
+                                                    }
+                                                </MudSelect>
+                                            </div>
+                                            <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigValueType)"
+                                                                 Text="@T(TranslationKeys.ValueConfigInfoValueType)" />
                                         </div>
-                                        <GenericInput For="() => editableResultConfig.Item.Address"></GenericInput>
-                                        <GenericInput For="() => editableResultConfig.Item.Length"></GenericInput>
+                                        <GenericInput For="() => editableResultConfig.Item.Address"
+                                                      InfoText="@T(TranslationKeys.ValueConfigInfoAddress)"></GenericInput>
+                                        <GenericInput For="() => editableResultConfig.Item.Length"
+                                                      InfoText="@T(TranslationKeys.ValueConfigInfoLength)"></GenericInput>
                                         @if (editableResultConfig.Item.ValueType == ModbusValueType.Bool)
                                         {
-                                            <GenericInput For="() => editableResultConfig.Item.BitStartIndex"></GenericInput>
+                                            <GenericInput For="() => editableResultConfig.Item.BitStartIndex"
+                                                          InfoText="@T(TranslationKeys.ValueConfigInfoBitStartIndex)"></GenericInput>
                                         }
                                         else
                                         {
@@ -115,7 +139,8 @@ else
                                         }
                                         <div class="row">
                                             <div class="col-12 col-md-6">
-                                                <div class="px-2 pt-2">
+                                                <div class="px-2 pt-2 d-flex align-center">
+                                                    <div class="flex-grow-1">
                                                     <MudSelect T="ValueOperator"
                                                                Class="@Constants.DefaultMargin"
                                                                Variant="Variant.Outlined"
@@ -128,10 +153,14 @@ else
                                                             <MudSelectItem T="ValueOperator" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
                                                         }
                                                     </MudSelect>
+                                                    </div>
+                                                    <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigOperator)"
+                                                                         Text="@T(TranslationKeys.ValueConfigInfoOperator)" />
                                                 </div>
                                             </div>
                                             <div class="col-12 col-md-6">
-                                                <GenericInput For="() => editableResultConfig.Item.CorrectionFactor"></GenericInput>
+                                                <GenericInput For="() => editableResultConfig.Item.CorrectionFactor"
+                                                              InfoText="@T(TranslationKeys.ValueConfigInfoCorrectionFactor)"></GenericInput>
                                             </div>
                                         </div>
                                     </div>
@@ -331,6 +360,6 @@ else
     }
 
     private string T(string key) =>
-        TextLocalizer.Get<ValueSourceConfigurationLocalizationRegistry>(key)
+        TextLocalizer.Get<ValueSourceConfigurationLocalizationRegistry>(key, typeof(ValueConfigurationInfoLocalizationRegistry))
         ?? key;
 }

--- a/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Mqtt/MqttValueConfigurationDialog.razor
+++ b/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Mqtt/MqttValueConfigurationDialog.razor
@@ -57,45 +57,56 @@ else
                             <ChildContent>
                                 <div class="d-flex align-items-center">
                                     <div class="p-2 flex-grow-1">
-                                        <GenericInput For="() => editableResultConfig.Item.Topic"></GenericInput>
-                                        <div class="px-2 pt-2">
-                                            <MudSelect T="NodePatternType"
-                                                       Class="@Constants.DefaultMargin"
-                                                       Variant="Variant.Outlined"
-                                                       Value="@editableResultConfig.Item.NodePatternType"
-                                                       ValueChanged="@((newValue) => UpdateNodePatternType(editableResultConfig.Item, newValue))"
-                                                       Label="@T(TranslationKeys.ValueSourceConfigNodePatternType)"
-                                                       Margin="Constants.InputMargin">
-                                                @foreach (NodePatternType item in Enum.GetValues(typeof(NodePatternType)))
-                                                {
-                                                    <MudSelectItem T="NodePatternType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                                                }
-                                            </MudSelect>
+                                        <GenericInput For="() => editableResultConfig.Item.Topic"
+                                                      InfoText="@T(TranslationKeys.ValueConfigInfoMqttTopic)"></GenericInput>
+                                        <div class="px-2 pt-2 d-flex align-center">
+                                            <div class="flex-grow-1">
+                                                <MudSelect T="NodePatternType"
+                                                           Class="@Constants.DefaultMargin"
+                                                           Variant="Variant.Outlined"
+                                                           Value="@editableResultConfig.Item.NodePatternType"
+                                                           ValueChanged="@((newValue) => UpdateNodePatternType(editableResultConfig.Item, newValue))"
+                                                           Label="@T(TranslationKeys.ValueSourceConfigNodePatternType)"
+                                                           Margin="Constants.InputMargin">
+                                                    @foreach (NodePatternType item in Enum.GetValues(typeof(NodePatternType)))
+                                                    {
+                                                        <MudSelectItem T="NodePatternType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                                    }
+                                                </MudSelect>
+                                            </div>
+                                            <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigNodePatternType)"
+                                                                 Text="@T(TranslationKeys.ValueConfigInfoDataFormat)" />
                                         </div>
-                                        <div class="p-2">
-                                            <MudSelect T="ValueUsage"
-                                                       Class="@Constants.DefaultMargin"
-                                                       Variant="Variant.Outlined"
-                                                       @bind-Value="@editableResultConfig.Item.UsedFor"
-                                                       Label="@T(TranslationKeys.ValueSourceConfigUsedFor)"
-                                                       Margin="Constants.InputMargin">
-                                                @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
-                                                {
-                                                    <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                                                }
-                                            </MudSelect>
+                                        <div class="p-2 d-flex align-center">
+                                            <div class="flex-grow-1">
+                                                <MudSelect T="ValueUsage"
+                                                           Class="@Constants.DefaultMargin"
+                                                           Variant="Variant.Outlined"
+                                                           @bind-Value="@editableResultConfig.Item.UsedFor"
+                                                           Label="@T(TranslationKeys.ValueSourceConfigUsedFor)"
+                                                           Margin="Constants.InputMargin">
+                                                    @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
+                                                    {
+                                                        <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                                    }
+                                                </MudSelect>
+                                            </div>
+                                            <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigUsedFor)"
+                                                                 Text="@T(TranslationKeys.ValueConfigInfoUsedFor)" />
                                         </div>
                                         <div class="row">
                                             @if (editableResultConfig.Item.NodePatternType != NodePatternType.Direct)
                                             {
                                                 <div class="col">
-                                                    <GenericInput For="() => editableResultConfig.Item.NodePattern"></GenericInput>
+                                                    <GenericInput For="() => editableResultConfig.Item.NodePattern"
+                                                                  InfoText="@T(TranslationKeys.ValueConfigInfoPathToValue)"></GenericInput>
                                                 </div>
                                             }
                                             @if (editableResultConfig.Item.NodePatternType == NodePatternType.Xml)
                                             {
                                                 <div>
-                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeHeaderName"></GenericInput>
+                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeHeaderName"
+                                                                  InfoText="@T(TranslationKeys.ValueConfigInfoXmlAttributeHeaderName)"></GenericInput>
                                                 </div>
                                             }
                                         </div>
@@ -103,33 +114,40 @@ else
                                         {
                                             <div class="col">
                                                 <div>
-                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeHeaderValue"></GenericInput>
+                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeHeaderValue"
+                                                                  InfoText="@T(TranslationKeys.ValueConfigInfoXmlAttributeHeaderValue)"></GenericInput>
                                                 </div>
                                                 <div>
-                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeValueName"></GenericInput>
+                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeValueName"
+                                                                  InfoText="@T(TranslationKeys.ValueConfigInfoXmlAttributeValueName)"></GenericInput>
                                                 </div>
                                             </div>
 
                                         }
                                         <div class="row">
                                             <div class="col-12 col-md-6">
-                                                <div class="p-2">
-                                                    <MudSelect T="ValueOperator"
-                                                               Class="@Constants.DefaultMargin"
-                                                               Variant="Variant.Outlined"
-                                                               Value="@editableResultConfig.Item.Operator"
-                                                               ValueChanged="(newItem) => UpdateOperator(editableResultConfig.Item, newItem)"
-                                                               Label="@T(TranslationKeys.ValueSourceConfigOperator)"
-                                                               Margin="Constants.InputMargin">
-                                                        @foreach (ValueOperator item in Enum.GetValues(typeof(ValueOperator)))
-                                                        {
-                                                            <MudSelectItem T="ValueOperator" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                                                        }
-                                                    </MudSelect>
+                                                <div class="p-2 d-flex align-center">
+                                                    <div class="flex-grow-1">
+                                                        <MudSelect T="ValueOperator"
+                                                                   Class="@Constants.DefaultMargin"
+                                                                   Variant="Variant.Outlined"
+                                                                   Value="@editableResultConfig.Item.Operator"
+                                                                   ValueChanged="(newItem) => UpdateOperator(editableResultConfig.Item, newItem)"
+                                                                   Label="@T(TranslationKeys.ValueSourceConfigOperator)"
+                                                                   Margin="Constants.InputMargin">
+                                                            @foreach (ValueOperator item in Enum.GetValues(typeof(ValueOperator)))
+                                                            {
+                                                                <MudSelectItem T="ValueOperator" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                                            }
+                                                        </MudSelect>
+                                                    </div>
+                                                    <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigOperator)"
+                                                                         Text="@T(TranslationKeys.ValueConfigInfoOperator)" />
                                                 </div>
                                             </div>
                                             <div class="col-12 col-md-6">
-                                                <GenericInput For="() => editableResultConfig.Item.CorrectionFactor"></GenericInput>
+                                                <GenericInput For="() => editableResultConfig.Item.CorrectionFactor"
+                                                              InfoText="@T(TranslationKeys.ValueConfigInfoCorrectionFactor)"></GenericInput>
                                             </div>
                                         </div>
                                     </div>
@@ -314,7 +332,7 @@ else
     }
 
     private string T(string key) =>
-        TextLocalizer.Get<ValueSourceConfigurationLocalizationRegistry>(key)
+        TextLocalizer.Get<ValueSourceConfigurationLocalizationRegistry>(key, typeof(ValueConfigurationInfoLocalizationRegistry))
         ?? key;
 
 }

--- a/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Rest/RestValueConfigurationDialog.razor
+++ b/TeslaSolarCharger/Client/Components/BaseConfiguration/ValueSources/Rest/RestValueConfigurationDialog.razor
@@ -30,25 +30,32 @@ else
         <ChildContent>
             <MudDialog>
                 <DialogContent>
-                    <div class="px-2 pt-2">
-                        <MudSelect T="HttpVerb"
-                                   Class="@Constants.DefaultMargin"
-                                   Variant="Variant.Outlined"
-                                   Value="@EditableRestValueConfiguration.Item.HttpMethod"
-                                   ValueChanged="(newItem) => UpdateHttpVerb(EditableRestValueConfiguration.Item, newItem)"
-                                   Label="@T(TranslationKeys.ValueSourceConfigHttpMethod)"
-                                   Margin="Constants.InputMargin">
-                            @foreach (HttpVerb item in Enum.GetValues(typeof(HttpVerb)))
-                            {
-                                <MudSelectItem T="HttpVerb" Value="@item">@ValueConfigurationEnumNames.Get(item)</MudSelectItem>
-                            }
-                        </MudSelect>
+                    <div class="px-2 pt-2 d-flex align-center">
+                        <div class="flex-grow-1">
+                            <MudSelect T="HttpVerb"
+                                       Class="@Constants.DefaultMargin"
+                                       Variant="Variant.Outlined"
+                                       Value="@EditableRestValueConfiguration.Item.HttpMethod"
+                                       ValueChanged="(newItem) => UpdateHttpVerb(EditableRestValueConfiguration.Item, newItem)"
+                                       Label="@T(TranslationKeys.ValueSourceConfigHttpMethod)"
+                                       Margin="Constants.InputMargin">
+                                @foreach (HttpVerb item in Enum.GetValues(typeof(HttpVerb)))
+                                {
+                                    <MudSelectItem T="HttpVerb" Value="@item">@ValueConfigurationEnumNames.Get(item)</MudSelectItem>
+                                }
+                            </MudSelect>
+                        </div>
+                        <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigHttpMethod)"
+                                             Text="@T(TranslationKeys.ValueConfigInfoHttpMethod)" />
                     </div>
-                    <GenericInput T="string" For="() => EditableRestValueConfiguration.Item.Url"></GenericInput>
+                    <GenericInput T="string" For="() => EditableRestValueConfiguration.Item.Url"
+                                  InfoText="@T(TranslationKeys.ValueConfigInfoRestUrl)"></GenericInput>
                     @if (EditableRestValueConfiguration.Item.Headers.Count > 0)
                     {
-                        <div class="fw-bold px-2 pt-2">
+                        <div class="fw-bold px-2 pt-2 d-flex align-center">
                             @T(TranslationKeys.ValueSourceConfigHeaders)
+                            <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigHeaders)"
+                                                 Text="@T(TranslationKeys.ValueConfigInfoHeaders)" />
                         </div>
                     }
                     @foreach (var header in EditableRestValueConfiguration.Item.Headers)
@@ -117,19 +124,23 @@ else
                         }
                     }
                     <hr />
-                    <div class="px-2 pt-2">
-                        <MudSelect T="NodePatternType"
-                                   Class="@Constants.DefaultMargin"
-                                   Variant="Variant.Outlined"
-                                   Value="@EditableRestValueConfiguration.Item.NodePatternType"
-                                   ValueChanged="@((newValue) => UpdateNodePatternType(EditableRestValueConfiguration.Item, newValue))"
-                                   Label="@T(TranslationKeys.ValueSourceConfigNodePatternType)"
-                                   Margin="Constants.InputMargin">
-                            @foreach (NodePatternType item in Enum.GetValues(typeof(NodePatternType)))
-                            {
-                                <MudSelectItem T="NodePatternType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                            }
-                        </MudSelect>
+                    <div class="px-2 pt-2 d-flex align-center">
+                        <div class="flex-grow-1">
+                            <MudSelect T="NodePatternType"
+                                       Class="@Constants.DefaultMargin"
+                                       Variant="Variant.Outlined"
+                                       Value="@EditableRestValueConfiguration.Item.NodePatternType"
+                                       ValueChanged="@((newValue) => UpdateNodePatternType(EditableRestValueConfiguration.Item, newValue))"
+                                       Label="@T(TranslationKeys.ValueSourceConfigNodePatternType)"
+                                       Margin="Constants.InputMargin">
+                                @foreach (NodePatternType item in Enum.GetValues(typeof(NodePatternType)))
+                                {
+                                    <MudSelectItem T="NodePatternType" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                }
+                            </MudSelect>
+                        </div>
+                        <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigNodePatternType)"
+                                             Text="@T(TranslationKeys.ValueConfigInfoDataFormat)" />
                     </div>
 
                     @foreach (var editableResultConfig in EditableRestResultConfigurations)
@@ -141,30 +152,36 @@ else
                             <ChildContent>
                                 <div class="d-flex align-items-center">
                                     <div class="p-2 flex-grow-1">
-                                        <div class="p-2">
-                                            <MudSelect T="ValueUsage"
-                                                       Class="@Constants.DefaultMargin"
-                                                       Variant="Variant.Outlined"
-                                                       @bind-Value="@editableResultConfig.Item.UsedFor"
-                                                       Label="@T(TranslationKeys.ValueSourceConfigUsedFor)"
-                                                       Margin="Constants.InputMargin">
-                                                @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
-                                                {
-                                                    <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                                                }
-                                            </MudSelect>
+                                        <div class="p-2 d-flex align-center">
+                                            <div class="flex-grow-1">
+                                                <MudSelect T="ValueUsage"
+                                                           Class="@Constants.DefaultMargin"
+                                                           Variant="Variant.Outlined"
+                                                           @bind-Value="@editableResultConfig.Item.UsedFor"
+                                                           Label="@T(TranslationKeys.ValueSourceConfigUsedFor)"
+                                                           Margin="Constants.InputMargin">
+                                                    @foreach (ValueUsage item in Enum.GetValues(typeof(ValueUsage)))
+                                                    {
+                                                        <MudSelectItem T="ValueUsage" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                                    }
+                                                </MudSelect>
+                                            </div>
+                                            <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigUsedFor)"
+                                                                 Text="@T(TranslationKeys.ValueConfigInfoUsedFor)" />
                                         </div>
                                         <div class="row">
                                             @if (EditableRestValueConfiguration.Item.NodePatternType != NodePatternType.Direct)
                                             {
                                                 <div class="col">
-                                                    <GenericInput For="() => editableResultConfig.Item.NodePattern"></GenericInput>
+                                                    <GenericInput For="() => editableResultConfig.Item.NodePattern"
+                                                                  InfoText="@T(TranslationKeys.ValueConfigInfoPathToValue)"></GenericInput>
                                                 </div>
                                             }
                                             @if (EditableRestValueConfiguration.Item.NodePatternType == NodePatternType.Xml)
                                             {
                                                 <div>
-                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeHeaderName"></GenericInput>
+                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeHeaderName"
+                                                                  InfoText="@T(TranslationKeys.ValueConfigInfoXmlAttributeHeaderName)"></GenericInput>
                                                 </div>
                                             }
                                         </div>
@@ -172,33 +189,40 @@ else
                                         {
                                             <div class="col">
                                                 <div>
-                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeHeaderValue"></GenericInput>
+                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeHeaderValue"
+                                                                  InfoText="@T(TranslationKeys.ValueConfigInfoXmlAttributeHeaderValue)"></GenericInput>
                                                 </div>
                                                 <div>
-                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeValueName"></GenericInput>
+                                                    <GenericInput For="() => editableResultConfig.Item.XmlAttributeValueName"
+                                                                  InfoText="@T(TranslationKeys.ValueConfigInfoXmlAttributeValueName)"></GenericInput>
                                                 </div>
                                             </div>
 
                                         }
                                         <div class="row">
                                             <div class="col-12 col-md-6">
-                                                <div class="p-2">
-                                                    <MudSelect T="ValueOperator"
-                                                               Class="@Constants.DefaultMargin"
-                                                               Variant="Variant.Outlined"
-                                                               Value="@editableResultConfig.Item.Operator"
-                                                               ValueChanged="(newItem) => UpdateOperator(editableResultConfig.Item, newItem)"
-                                                               Label="@T(TranslationKeys.ValueSourceConfigOperator)"
-                                                               Margin="Constants.InputMargin">
-                                                        @foreach (ValueOperator item in Enum.GetValues(typeof(ValueOperator)))
-                                                        {
-                                                            <MudSelectItem T="ValueOperator" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
-                                                        }
-                                                    </MudSelect>
+                                                <div class="p-2 d-flex align-center">
+                                                    <div class="flex-grow-1">
+                                                        <MudSelect T="ValueOperator"
+                                                                   Class="@Constants.DefaultMargin"
+                                                                   Variant="Variant.Outlined"
+                                                                   Value="@editableResultConfig.Item.Operator"
+                                                                   ValueChanged="(newItem) => UpdateOperator(editableResultConfig.Item, newItem)"
+                                                                   Label="@T(TranslationKeys.ValueSourceConfigOperator)"
+                                                                   Margin="Constants.InputMargin">
+                                                            @foreach (ValueOperator item in Enum.GetValues(typeof(ValueOperator)))
+                                                            {
+                                                                <MudSelectItem T="ValueOperator" Value="@item">@ValueConfigurationEnumNames.Get(TextLocalizer, item)</MudSelectItem>
+                                                            }
+                                                        </MudSelect>
+                                                    </div>
+                                                    <InfoButtonComponent Title="@T(TranslationKeys.ValueSourceConfigOperator)"
+                                                                         Text="@T(TranslationKeys.ValueConfigInfoOperator)" />
                                                 </div>
                                             </div>
                                             <div class="col-12 col-md-6">
-                                                <GenericInput For="() => editableResultConfig.Item.CorrectionFactor"></GenericInput>
+                                                <GenericInput For="() => editableResultConfig.Item.CorrectionFactor"
+                                                              InfoText="@T(TranslationKeys.ValueConfigInfoCorrectionFactor)"></GenericInput>
                                             </div>
                                         </div>
                                     </div>
@@ -418,7 +442,7 @@ else
     }
 
     private string T(string key) =>
-        TextLocalizer.Get<ValueSourceConfigurationLocalizationRegistry>(key)
+        TextLocalizer.Get<ValueSourceConfigurationLocalizationRegistry>(key, typeof(ValueConfigurationInfoLocalizationRegistry))
         ?? key;
 
 }

--- a/TeslaSolarCharger/Client/Components/GenericInput.razor
+++ b/TeslaSolarCharger/Client/Components/GenericInput.razor
@@ -388,6 +388,10 @@
                 </MudFab>
             </div>
         }
+        @if (!string.IsNullOrEmpty(InfoText))
+        {
+            <InfoButtonComponent Title="@(string.IsNullOrEmpty(InfoTitle) ? LabelName : InfoTitle)" Text="@InfoText" />
+        }
     </div>
 }
 
@@ -574,6 +578,19 @@
 
     [Parameter]
     public string? PostfixButtonStartIcon { get; set; }
+
+    /// <summary>
+    /// Explanation shown behind the input in an info dialog. Pass it already localized. Nothing is rendered while
+    /// this is empty.
+    /// </summary>
+    [Parameter]
+    public string? InfoText { get; set; }
+
+    /// <summary>
+    /// Title of the info dialog. Defaults to the input's label.
+    /// </summary>
+    [Parameter]
+    public string? InfoTitle { get; set; }
 
     [Parameter]
     public bool? IsButtonDisabled { get; set; }

--- a/TeslaSolarCharger/Client/Components/InfoButtonComponent.razor
+++ b/TeslaSolarCharger/Client/Components/InfoButtonComponent.razor
@@ -1,0 +1,22 @@
+@using TeslaSolarCharger.Client.Helper.Contracts
+
+@inject IDialogHelper DialogHelper
+
+@* Small info affordance next to an input: opens a dialog explaining what the value means. The texts are passed in
+   already localized so the component stays usable from any page. *@
+
+<MudIconButton Icon="@Icons.Material.Outlined.Info"
+               Size="Size.Small"
+               Color="Color.Default"
+               aria-label="@Title"
+               OnClick="ShowInfo" />
+
+@code {
+    [Parameter, EditorRequired]
+    public string Title { get; set; } = string.Empty;
+
+    [Parameter, EditorRequired]
+    public string Text { get; set; } = string.Empty;
+
+    private Task ShowInfo() => DialogHelper.ShowTextDialog(Title, Text);
+}

--- a/TeslaSolarCharger/Client/Dialogs/TextDialog.razor
+++ b/TeslaSolarCharger/Client/Dialogs/TextDialog.razor
@@ -6,7 +6,9 @@
 
 <MudDialog>
     <DialogContent>
-        @(Text)
+        @* Explanations and error details are written with line breaks, so keep them instead of collapsing
+           everything into one paragraph. *@
+        <div style="white-space: pre-line;">@(Text)</div>
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Submit">@T(TranslationKeys.TextDialogOk)</MudButton>

--- a/TeslaSolarCharger/Shared/Localization/Registries/Components/ValueConfigurationInfoLocalizationRegistry.cs
+++ b/TeslaSolarCharger/Shared/Localization/Registries/Components/ValueConfigurationInfoLocalizationRegistry.cs
@@ -1,0 +1,253 @@
+namespace TeslaSolarCharger.Shared.Localization.Registries.Components;
+
+/// <summary>
+/// Explanations shown behind the inputs of the REST, MQTT and Modbus value configuration dialogs. The content
+/// follows the "Setting up solar power values" chapter of the README, so users no longer have to leave the app to
+/// find out what a field expects.
+/// </summary>
+public class ValueConfigurationInfoLocalizationRegistry : TextLocalizationRegistry<ValueConfigurationInfoLocalizationRegistry>
+{
+    protected override void Configure()
+    {
+        Register(TranslationKeys.ValueConfigInfoUsedFor,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                Which of the four values TSC needs is read here. TSC expects:
+
+                Inverter power: solar power generated, a positive number in watts.
+                Grid power: watts, export to the grid positive, import from the grid negative.
+                Home battery power: watts, charging positive, discharging negative.
+                Home battery SoC: percent from 0 to 100.
+
+                If your device reports something else, correct it with the operator and the correction factor.
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Welchen der vier Werte, die TSC benötigt, dieser Eintrag liefert. TSC erwartet:
+
+                Wechselrichterleistung: erzeugte Solarleistung als positive Zahl in Watt.
+                Netzleistung: Watt, Einspeisung positiv, Bezug negativ.
+                Heimspeicherleistung: Watt, Laden positiv, Entladen negativ.
+                Heimspeicher-Ladestand: Prozent von 0 bis 100.
+
+                Liefert Ihr Gerät etwas anderes, korrigieren Sie das über Operator und Korrekturfaktor.
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoOperator,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                Whether the value is used as it is (Plus) or with its sign flipped (Minus).
+
+                Example: your device reports the power drawn from the grid as a positive number, but TSC expects an
+                import to be negative. Select Minus.
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Ob der Wert unverändert übernommen wird (Plus) oder mit umgekehrtem Vorzeichen (Minus).
+
+                Beispiel: Ihr Gerät meldet den Netzbezug als positive Zahl, TSC erwartet den Bezug aber negativ.
+                Wählen Sie Minus.
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoCorrectionFactor,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                The value is multiplied by this factor so the result is what TSC expects: watts, or percent for the
+                home battery SoC.
+
+                Examples:
+                Value already in watts: 1
+                Value in kilowatts: 1000
+                Home battery SoC reported in kWh and the battery holds 100 kWh: 0.01
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Der Wert wird mit diesem Faktor multipliziert, damit das Ergebnis dem entspricht, was TSC erwartet:
+                Watt, beim Heimspeicher-Ladestand Prozent.
+
+                Beispiele:
+                Wert bereits in Watt: 1
+                Wert in Kilowatt: 1000
+                Heimspeicher-Ladestand wird in kWh gemeldet und der Speicher fasst 100 kWh: 0,01
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoDataFormat,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                How the answer of your device has to be read.
+
+                Single value: the answer is the value itself, e.g. 1234.
+                JSON: the value is picked out of a JSON answer.
+                XML: the value is picked out of an XML answer.
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Wie die Antwort Ihres Geräts gelesen werden muss.
+
+                Einzelner Wert: die Antwort ist der Wert selbst, z. B. 1234.
+                JSON: der Wert wird aus einer JSON-Antwort herausgesucht.
+                XML: der Wert wird aus einer XML-Antwort herausgesucht.
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoPathToValue,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                Where the value sits inside the answer.
+
+                JSON: for {"data": {"value": 14}} use $.data.value
+                XML: for <Device><Measurements><Measurement Value="18.7" Type="GridPower"/></Measurements></Device>
+                use Device/Measurements/Measurement and pick the right node with the three XML attribute fields.
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Wo der Wert innerhalb der Antwort steht.
+
+                JSON: für {"data": {"value": 14}} verwenden Sie $.data.value
+                XML: für <Device><Measurements><Measurement Value="18.7" Type="GridPower"/></Measurements></Device>
+                verwenden Sie Device/Measurements/Measurement und wählen den richtigen Knoten über die drei
+                XML-Attribut-Felder aus.
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoXmlAttributeHeaderName,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                Name of the attribute that tells the nodes apart when the path matches more than one node.
+
+                For <Measurement Value="18.7" Unit="W" Type="GridPower"/> this is Type.
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Name des Attributs, an dem die Knoten unterschieden werden, wenn der Pfad mehrere Knoten trifft.
+
+                Bei <Measurement Value="18.7" Unit="W" Type="GridPower"/> ist das Type.
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoXmlAttributeHeaderValue,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                Value that attribute has to have for the node you want.
+
+                For <Measurement Value="18.7" Unit="W" Type="GridPower"/> this is GridPower.
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Wert, den dieses Attribut beim gesuchten Knoten haben muss.
+
+                Bei <Measurement Value="18.7" Unit="W" Type="GridPower"/> ist das GridPower.
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoXmlAttributeValueName,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                Name of the attribute that carries the value itself.
+
+                For <Measurement Value="18.7" Unit="W" Type="GridPower"/> this is Value.
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Name des Attributs, das den Wert selbst enthält.
+
+                Bei <Measurement Value="18.7" Unit="W" Type="GridPower"/> ist das Value.
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoRestUrl,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                """
+                The complete URL TSC calls to read the values, including protocol and port.
+
+                Example for the SolarEdge plugin:
+                http://<IP of your Docker host>:7193/api/CurrentValues/GetCurrentPvValues
+                """),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                """
+                Die vollständige URL, die TSC zum Auslesen der Werte aufruft, inklusive Protokoll und Port.
+
+                Beispiel für das SolarEdge-Plugin:
+                http://<IP Ihres Docker-Hosts>:7193/api/CurrentValues/GetCurrentPvValues
+                """));
+
+        Register(TranslationKeys.ValueConfigInfoHttpMethod,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "HTTP method used for the request. Only GET is supported at the moment."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "HTTP-Methode für die Anfrage. Aktuell wird nur GET unterstützt."));
+
+        Register(TranslationKeys.ValueConfigInfoHeaders,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Optional HTTP headers sent with every request, e.g. an authorization token your device requires."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Optionale HTTP-Header, die bei jeder Anfrage mitgesendet werden, z. B. ein Token, das Ihr Gerät zur Authentifizierung verlangt."));
+
+        Register(TranslationKeys.ValueConfigInfoModbusHost,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "IP address or hostname of your inverter."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "IP-Adresse oder Hostname Ihres Wechselrichters."));
+
+        Register(TranslationKeys.ValueConfigInfoModbusPort,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Modbus TCP port of your inverter. 502 in most cases."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Modbus-TCP-Port Ihres Wechselrichters. In den meisten Fällen 502."));
+
+        Register(TranslationKeys.ValueConfigInfoUnitIdentifier,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Internal Modbus ID of your inverter, in most cases 1 or 3. Your inverter's documentation states which one it uses."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Interne Modbus-ID Ihres Wechselrichters, in den meisten Fällen 1 oder 3. Die Dokumentation Ihres Wechselrichters nennt den richtigen Wert."));
+
+        Register(TranslationKeys.ValueConfigInfoConnectDelay,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "How long TSC waits after connecting before it sends the first request. 1000 ms works with most devices."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Wie lange TSC nach dem Verbinden wartet, bevor die erste Anfrage gesendet wird. 1000 ms funktionieren bei den meisten Geräten."));
+
+        Register(TranslationKeys.ValueConfigInfoReadTimeout,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "How long TSC waits for an answer before it reports an error. 1000 ms works with most devices."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Wie lange TSC auf eine Antwort wartet, bevor ein Fehler gemeldet wird. 1000 ms funktionieren bei den meisten Geräten."));
+
+        Register(TranslationKeys.ValueConfigInfoEndianess,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Byte order your device uses for values that span several registers. Big endian is the Modbus default; if you get implausible values, try little endian."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Byte-Reihenfolge, die Ihr Gerät für Werte über mehrere Register verwendet. Big Endian ist der Modbus-Standard; bei unplausiblen Werten probieren Sie Little Endian."));
+
+        Register(TranslationKeys.ValueConfigInfoRegisterType,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Which register table the value is read from. Your inverter's documentation states whether the address is a holding register or an input register."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Aus welcher Registertabelle der Wert gelesen wird. Die Dokumentation Ihres Wechselrichters gibt an, ob die Adresse ein Holding- oder ein Input-Register ist."));
+
+        Register(TranslationKeys.ValueConfigInfoValueType,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Data type of the register content as documented by your inverter, e.g. Int 32 for a 32 bit value spanning two registers. A wrong type results in implausible values."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Datentyp des Registerinhalts laut Dokumentation Ihres Wechselrichters, z. B. Int 32 für einen 32-Bit-Wert über zwei Register. Ein falscher Typ führt zu unplausiblen Werten."));
+
+        Register(TranslationKeys.ValueConfigInfoAddress,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Register address of the value, taken from your inverter's documentation."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Registeradresse des Werts laut Dokumentation Ihres Wechselrichters."));
+
+        Register(TranslationKeys.ValueConfigInfoLength,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Number of registers to read: two for 32 bit values, one for 16 bit values, four for 64 bit values."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Anzahl der zu lesenden Register: zwei bei 32-Bit-Werten, eins bei 16-Bit-Werten, vier bei 64-Bit-Werten."));
+
+        Register(TranslationKeys.ValueConfigInfoBitStartIndex,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Only needed for the Bool type: position of the bit inside the register that carries the value, counted from 0."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Nur beim Typ Bool nötig: Position des Bits innerhalb des Registers, das den Wert enthält, gezählt ab 0."));
+
+        Register(TranslationKeys.ValueConfigInfoMqttTopic,
+            new TextLocalizationTranslation(LanguageCodes.English,
+                "Topic that carries the value, e.g. inverter/grid/power. TSC subscribes to it and uses the last message it received."),
+            new TextLocalizationTranslation(LanguageCodes.German,
+                "Topic, über das der Wert veröffentlicht wird, z. B. inverter/grid/power. TSC abonniert es und verwendet die zuletzt empfangene Nachricht."));
+    }
+}

--- a/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
+++ b/TeslaSolarCharger/Shared/Localization/TranslationKeys.cs
@@ -371,6 +371,30 @@ public static class TranslationKeys
     public static string ModbusEndianessBig => nameof(ModbusEndianessBig);
     public static string ModbusEndianessLittle => nameof(ModbusEndianessLittle);
 
+    public static string ValueConfigInfoUsedFor => nameof(ValueConfigInfoUsedFor);
+    public static string ValueConfigInfoOperator => nameof(ValueConfigInfoOperator);
+    public static string ValueConfigInfoCorrectionFactor => nameof(ValueConfigInfoCorrectionFactor);
+    public static string ValueConfigInfoDataFormat => nameof(ValueConfigInfoDataFormat);
+    public static string ValueConfigInfoPathToValue => nameof(ValueConfigInfoPathToValue);
+    public static string ValueConfigInfoXmlAttributeHeaderName => nameof(ValueConfigInfoXmlAttributeHeaderName);
+    public static string ValueConfigInfoXmlAttributeHeaderValue => nameof(ValueConfigInfoXmlAttributeHeaderValue);
+    public static string ValueConfigInfoXmlAttributeValueName => nameof(ValueConfigInfoXmlAttributeValueName);
+    public static string ValueConfigInfoRestUrl => nameof(ValueConfigInfoRestUrl);
+    public static string ValueConfigInfoHttpMethod => nameof(ValueConfigInfoHttpMethod);
+    public static string ValueConfigInfoHeaders => nameof(ValueConfigInfoHeaders);
+    public static string ValueConfigInfoModbusHost => nameof(ValueConfigInfoModbusHost);
+    public static string ValueConfigInfoModbusPort => nameof(ValueConfigInfoModbusPort);
+    public static string ValueConfigInfoUnitIdentifier => nameof(ValueConfigInfoUnitIdentifier);
+    public static string ValueConfigInfoConnectDelay => nameof(ValueConfigInfoConnectDelay);
+    public static string ValueConfigInfoReadTimeout => nameof(ValueConfigInfoReadTimeout);
+    public static string ValueConfigInfoEndianess => nameof(ValueConfigInfoEndianess);
+    public static string ValueConfigInfoRegisterType => nameof(ValueConfigInfoRegisterType);
+    public static string ValueConfigInfoValueType => nameof(ValueConfigInfoValueType);
+    public static string ValueConfigInfoAddress => nameof(ValueConfigInfoAddress);
+    public static string ValueConfigInfoLength => nameof(ValueConfigInfoLength);
+    public static string ValueConfigInfoBitStartIndex => nameof(ValueConfigInfoBitStartIndex);
+    public static string ValueConfigInfoMqttTopic => nameof(ValueConfigInfoMqttTopic);
+
     public static string ValueSourceConfigFormNull => nameof(ValueSourceConfigFormNull);
     public static string ValueSourceConfigConfigNull => nameof(ValueSourceConfigConfigNull);
     public static string ValueSourceConfigConfigInvalid => nameof(ValueSourceConfigConfigInvalid);

--- a/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Shared/ServiceCollectionExtensions.cs
@@ -89,5 +89,6 @@ public static class ServiceCollectionExtensions
             .AddSingleton<ITextLocalizationRegistry, DialogsLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, TimeSeriesChartPageLocalizationRegistry>()
             .AddSingleton<ITextLocalizationRegistry, ValueSourceConfigurationLocalizationRegistry>()
+            .AddSingleton<ITextLocalizationRegistry, ValueConfigurationInfoLocalizationRegistry>()
         ;
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #2851, which renames the fields these explanations refer to. Merge #2851 first; the base switches to `develop` automatically afterwards.

Setting up a REST, MQTT or Modbus source meant guessing what a field wants or leaving the app to look it up in the README. Every input of the three dialogs now has an info button next to it that opens the explanation.

**What is explained** (content follows the README's *Setting up solar power values* chapter):

- *Used for*, with the unit and sign TSC expects per value (watts, export positive / import negative, SoC in percent)
- *Operator* and *Correction factor*, with the kW → W and SoC-in-kWh examples
- *Data format* and *Path to value*, with the JSON (`$.data.value`) and XML (`Device/Measurements/Measurement`) examples
- the three XML attribute fields, explained against the `<Measurement Value="18.7" Type="GridPower"/>` example
- REST url, HTTP method, headers
- Modbus host, port, unit id, connect delay, read timeout, endianness, register type, value type, address, length, bit start index
- MQTT topic

**How it is built**

- `InfoButtonComponent` renders the icon and opens the existing `TextDialog` through `IDialogHelper` - no new dialog type.
- `GenericInput` gained an `InfoText` (and optional `InfoTitle`) parameter, so a field only needs one extra attribute and the button always sits in the same place. Hand written `MudSelect`s use the component directly.
- `TextDialog` keeps line breaks now (`white-space: pre-line`), which also improves the error dialogs that already use it.
- The texts live in their own `ValueConfigurationInfoLocalizationRegistry` in English and German.

24 new tests assert that every info key resolves in both languages - a missing registration would otherwise silently show the key name in the dialog. Full suite: 961 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)