### PR TITLE
fix(chargingCost): keep energy of meter values logged before v2.40.0

### DIFF
--- a/TeslaSolarCharger.Tests/Services/Server/TscOnlyChargingCostServiceTests.cs
+++ b/TeslaSolarCharger.Tests/Services/Server/TscOnlyChargingCostServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using TeslaSolarCharger.Model.Entities.TeslaSolarCharger;
+using TeslaSolarCharger.Model.Enums;
 using TeslaSolarCharger.Server.Services.GridPrice.Dtos;
 using TeslaSolarCharger.Shared.Enums;
 using Xunit;
@@ -128,6 +129,87 @@ public class TscOnlyChargingCostServiceTests : TestBase
         {
             Assert.Equal(expectedGridPrice, price.GridPrice);
         }
+    }
+
+    [Theory]
+    //Interval used before v2.40.0. Meter values of every charging process recorded back then still have this spacing,
+    //so a threshold derived from the current interval discarded all of them and zeroed the charged energy (issue #2768).
+    [InlineData(59)]
+    //Current interval.
+    [InlineData(11)]
+    public void CalculateChargedEnergyAndCost_UsesMeterValuesOfAnyLoggingInterval(int loggingIntervalSeconds)
+    {
+        // Arrange
+        var service = Mock.Create<TeslaSolarCharger.Server.Services.TscOnlyChargingCostService>();
+        var start = new DateTimeOffset(2025, 8, 25, 9, 0, 0, TimeSpan.Zero);
+        const int intervalCount = 60;
+        //Charging with 6000 W in total, of which 1000 W come from the grid and 500 W from the home battery.
+        var meterValues = GenerateMeterValues(start, TimeSpan.FromSeconds(loggingIntervalSeconds),
+            intervalCount, 6000, 1000, 500);
+        var prices = SinglePrice(start.AddDays(-1), start.AddDays(1), gridPrice: 0.30m, solarPrice: 0.10m);
+
+        // Act
+        var result = service.CalculateChargedEnergyAndCost(meterValues, prices);
+
+        // Assert
+        //The first meter value only starts the process, so energy is charged during the intervals following it.
+        var chargedHours = intervalCount * loggingIntervalSeconds / 3600d;
+        Assert.Equal(4500 * chargedHours, (double)result.SolarEnergyWh, 6);
+        Assert.Equal(1000 * chargedHours, (double)result.GridEnergyWh, 6);
+        Assert.Equal(500 * chargedHours, (double)result.HomeBatteryEnergyWh, 6);
+        //Grid energy is billed with the grid price, solar and home battery energy with the solar price.
+        Assert.Equal(((1000 * 0.30) + (5000 * 0.10)) * chargedHours, (double)result.Cost, 6);
+    }
+
+    [Fact]
+    public void CalculateChargedEnergyAndCost_IgnoresMeterValuesAfterALongPause()
+    {
+        // Arrange
+        var service = Mock.Create<TeslaSolarCharger.Server.Services.TscOnlyChargingCostService>();
+        var start = new DateTimeOffset(2025, 8, 25, 9, 0, 0, TimeSpan.Zero);
+        var meterValues = GenerateMeterValues(start, TimeSpan.FromSeconds(11), 1, 6000, 1000, 500);
+        //The car was unplugged and plugged in again an hour later, so the power of the meter value after the pause
+        //must not be applied to the whole pause.
+        meterValues.Add(new MeterValue(start.AddHours(1), MeterValueKind.Car, 6000)
+        {
+            CarId = 1, MeasuredGridPower = 1000, MeasuredHomeBatteryPower = 500,
+        });
+        var prices = SinglePrice(start.AddDays(-1), start.AddDays(1), gridPrice: 0.30m, solarPrice: 0.10m);
+
+        // Act
+        var result = service.CalculateChargedEnergyAndCost(meterValues, prices);
+
+        // Assert
+        //Only the 11 seconds between the first two meter values are counted, the hour long gap is skipped.
+        var chargedHours = 11 / 3600d;
+        Assert.Equal(4500 * chargedHours, (double)result.SolarEnergyWh, 6);
+        Assert.Equal(1000 * chargedHours, (double)result.GridEnergyWh, 6);
+        Assert.Equal(500 * chargedHours, (double)result.HomeBatteryEnergyWh, 6);
+    }
+
+    private static List<MeterValue> GenerateMeterValues(DateTimeOffset start, TimeSpan interval, int intervalCount,
+        int measuredPower, int measuredGridPower, int measuredHomeBatteryPower)
+    {
+        var meterValues = new List<MeterValue>();
+        for (var i = 0; i <= intervalCount; i++)
+        {
+            meterValues.Add(new MeterValue(start.Add(interval * i), MeterValueKind.Car, measuredPower)
+            {
+                CarId = 1,
+                MeasuredGridPower = measuredGridPower,
+                MeasuredHomeBatteryPower = measuredHomeBatteryPower,
+            });
+        }
+
+        return meterValues;
+    }
+
+    private static List<Price> SinglePrice(DateTimeOffset validFrom, DateTimeOffset validTo, decimal gridPrice, decimal solarPrice)
+    {
+        return new List<Price>
+        {
+            new() { ValidFrom = validFrom, ValidTo = validTo, GridPrice = gridPrice, SolarPrice = solarPrice },
+        };
     }
 
     public static TheoryData<string, DateTimeOffset, DateTimeOffset, List<(DateTimeOffset Start, decimal Price)>, List<(DateTimeOffset From, DateTimeOffset To)>> GetSpotPriceScenarios()

--- a/TeslaSolarCharger/Server/Services/TscOnlyChargingCostService.cs
+++ b/TeslaSolarCharger/Server/Services/TscOnlyChargingCostService.cs
@@ -231,40 +231,57 @@ public class TscOnlyChargingCostService(ILogger<TscOnlyChargingCostService> logg
             context.MeterValues.Add(fakeMeterValue);
             meterValues.Add(fakeMeterValue);
         }
+        chargingProcess.EndDate = meterValues.Last().Timestamp.UtcDateTime;
+        var prices = await GetGridPricesInTimeSpan(meterValues.First().Timestamp.UtcDateTime, chargingProcess.EndDate.Value);
+        var energyAndCost = CalculateChargedEnergyAndCost(meterValues, prices);
+        chargingProcess.UsedSolarEnergyKwh = energyAndCost.SolarEnergyWh / 1000m;
+        chargingProcess.UsedHomeBatteryEnergyKwh = energyAndCost.HomeBatteryEnergyWh / 1000m;
+        chargingProcess.UsedGridEnergyKwh = energyAndCost.GridEnergyWh / 1000m;
+        chargingProcess.Cost = energyAndCost.Cost / 1000m;
+        await context.SaveChangesAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Integrates the measured power of the given meter values over time to get the charged energy and its cost.
+    /// </summary>
+    /// <param name="meterValues">Meter values of one charging process, ordered ascending by timestamp.</param>
+    /// <param name="prices">Prices covering the time span of the given meter values.</param>
+    /// <returns>Charged energy in Wh per source and the cost in currency * 1000.</returns>
+    internal (decimal SolarEnergyWh, decimal HomeBatteryEnergyWh, decimal GridEnergyWh, decimal Cost) CalculateChargedEnergyAndCost(
+        List<MeterValue> meterValues, List<Price> prices)
+    {
+        logger.LogTrace("{method}({meterValueCount})", nameof(CalculateChargedEnergyAndCost), meterValues.Count);
         decimal usedSolarEnergyWh = 0;
         decimal usedHomeBatteryEnergyWh = 0;
         decimal usedGridEnergyWh = 0;
         decimal cost = 0;
-        chargingProcess.EndDate = meterValues.Last().Timestamp.UtcDateTime;
-        var prices = await GetGridPricesInTimeSpan(meterValues.First().Timestamp.UtcDateTime, chargingProcess.EndDate.Value);        //When a charging process is stopped and resumed later, the last charging detail is too old and should not be used because it would use the last value dring the whole time althoug the car was not charging
-        var maxChargingDetailsDuration = TimeSpan.FromSeconds(constants.ChargingDetailsAddTriggerEveryXSeconds).Add(TimeSpan.FromSeconds(10));
+        //When a charging process is stopped and resumed later, the last meter value is too old and should not be used because it would use the last value during the whole time although the car was not charging
+        var maxMeterValueGap = constants.MaxMeterValueGapForEnergyCalculation;
         for (var index = 1; index < meterValues.Count; index++)
         {
             var price = GetPriceByTimeStamp(prices, meterValues[index].Timestamp.UtcDateTime);
             logger.LogTrace("Price for timestamp {timeStamp}: {@price}", meterValues[index].Timestamp, price);
             var meterValue = meterValues[index];
-            var timeSpanSinceLastDetail = meterValue.Timestamp - meterValues[index - 1].Timestamp;
+            var timeSpanSinceLastMeterValue = meterValue.Timestamp - meterValues[index - 1].Timestamp;
 
-            if (timeSpanSinceLastDetail > maxChargingDetailsDuration)
+            if (timeSpanSinceLastMeterValue > maxMeterValueGap)
             {
-                logger.LogWarning("Do not use charging detail as last charging detail ist too old");
+                logger.LogWarning("Do not use meter value {meterValueTimestamp} as the previous meter value is {gap} old, which is more than the allowed {maxGap}",
+                    meterValue.Timestamp, timeSpanSinceLastMeterValue, maxMeterValueGap);
                 continue;
             }
-            var usedSolarWhSinceLastChargingDetail = (decimal)((meterValue.MeasuredPower - meterValue.MeasuredHomeBatteryPower - meterValue.MeasuredGridPower) * timeSpanSinceLastDetail.TotalHours);
-            usedSolarEnergyWh += usedSolarWhSinceLastChargingDetail;
-            var usedHomeBatteryWhSinceLastChargingDetail = (decimal)(meterValue.MeasuredHomeBatteryPower * timeSpanSinceLastDetail.TotalHours);
-            usedHomeBatteryEnergyWh += usedHomeBatteryWhSinceLastChargingDetail;
-            var usedGridPowerSinceLastChargingDetail = (decimal)(meterValue.MeasuredGridPower * timeSpanSinceLastDetail.TotalHours);
-            usedGridEnergyWh += usedGridPowerSinceLastChargingDetail;
-            cost += usedGridPowerSinceLastChargingDetail * price.GridPrice;
-            cost += usedSolarWhSinceLastChargingDetail * price.SolarPrice;
-            cost += usedHomeBatteryWhSinceLastChargingDetail * price.SolarPrice;
+            var usedSolarWhSinceLastMeterValue = (decimal)((meterValue.MeasuredPower - meterValue.MeasuredHomeBatteryPower - meterValue.MeasuredGridPower) * timeSpanSinceLastMeterValue.TotalHours);
+            usedSolarEnergyWh += usedSolarWhSinceLastMeterValue;
+            var usedHomeBatteryWhSinceLastMeterValue = (decimal)(meterValue.MeasuredHomeBatteryPower * timeSpanSinceLastMeterValue.TotalHours);
+            usedHomeBatteryEnergyWh += usedHomeBatteryWhSinceLastMeterValue;
+            var usedGridPowerSinceLastMeterValue = (decimal)(meterValue.MeasuredGridPower * timeSpanSinceLastMeterValue.TotalHours);
+            usedGridEnergyWh += usedGridPowerSinceLastMeterValue;
+            cost += usedGridPowerSinceLastMeterValue * price.GridPrice;
+            cost += usedSolarWhSinceLastMeterValue * price.SolarPrice;
+            cost += usedHomeBatteryWhSinceLastMeterValue * price.SolarPrice;
         }
-        chargingProcess.UsedSolarEnergyKwh = usedSolarEnergyWh / 1000m;
-        chargingProcess.UsedHomeBatteryEnergyKwh = usedHomeBatteryEnergyWh / 1000m;
-        chargingProcess.UsedGridEnergyKwh = usedGridEnergyWh / 1000m;
-        chargingProcess.Cost = cost / 1000m;
-        await context.SaveChangesAsync().ConfigureAwait(false);
+
+        return (usedSolarEnergyWh, usedHomeBatteryEnergyWh, usedGridEnergyWh, cost);
     }
 
     private Price GetPriceByTimeStamp(List<Price> prices, DateTime timeStamp)

--- a/TeslaSolarCharger/Shared/Resources/Constants.cs
+++ b/TeslaSolarCharger/Shared/Resources/Constants.cs
@@ -31,6 +31,10 @@ public class Constants : IConstants
     public TimeSpan MinTokenRestLifetime => TimeSpan.FromMinutes(2);
     public int MaxTokenUnauthorizedCount => 5;
     public int ChargingDetailsAddTriggerEveryXSeconds => 11;
+    //Must NOT be derived from ChargingDetailsAddTriggerEveryXSeconds: charging energy is recalculated from historic
+    //meter values, which were logged with the interval that was configured back then (59 seconds before v2.40.0).
+    //A threshold based on the current interval discards every older meter value and zeroes the charged energy.
+    public TimeSpan MaxMeterValueGapForEnergyCalculation => TimeSpan.FromMinutes(5);
     public string ChargeStartRequestUrl => "FleetApiRequests/ChargeStart";
     public string ChargeStopRequestUrl => "FleetApiRequests/ChargeStop";
     public string SetChargingAmpsRequestUrl => "FleetApiRequests/SetChargingAmps";

--- a/TeslaSolarCharger/Shared/Resources/Contracts/IConstants.cs
+++ b/TeslaSolarCharger/Shared/Resources/Contracts/IConstants.cs
@@ -28,6 +28,7 @@ public interface IConstants
     string HandledChargesConverted { get; }
     string GridPoleIcon { get; }
     int ChargingDetailsAddTriggerEveryXSeconds { get; }
+    TimeSpan MaxMeterValueGapForEnergyCalculation { get; }
     string ChargingDetailsSolarPowerShareFixed { get; }
     string SolarValuesConverted { get; }
     string ChargeStartRequestUrl { get; }


### PR DESCRIPTION
Fixes #2768

## Problem

`FinalizeChargingProcess` derived the maximum allowed gap between two meter values from the *current* logging interval:

```csharp
var maxChargingDetailsDuration = TimeSpan.FromSeconds(constants.ChargingDetailsAddTriggerEveryXSeconds).Add(TimeSpan.FromSeconds(10));
```

1ee63b90 reduced `ChargingDetailsAddTriggerEveryXSeconds` from 59 to 11, so the threshold dropped from 69 to 21 seconds. Meter values recorded before v2.40.0 — including everything imported from `ChargingDetails` — are still spaced ~59 seconds apart, so **every** interval hit `continue` and contributed nothing.

Any recalculation of all charging processes (adding, editing or deleting a charge price) therefore reset `Cost`, `UsedGridEnergyKwh`, `UsedHomeBatteryEnergyKwh` and `UsedSolarEnergyKwh` of every charging process older than v2.40.0 to almost zero. This matches the reporter's log, which contained the "last charging detail ist too old" warning about 57 000 times.

## Analysis of the reporter's backups

Both backups were queried directly. The break is exactly at v2.40.0 (tagged 2025-08-25):

| gaps between car meter values | ≤ 21 s | 21–70 s | > 70 s |
|---|---|---|---|
| 2025-06 | 192 | 5916 | 97 |
| 2025-08 | 2119 | 5176 | 79 |
| 2025-09 | 30568 | 3 | 87 |

Sums over `ChargingProcesses` with `Id < 882`:

| | before | after |
|---|---|---|
| solar kWh | 2374.62 | 0.452 |
| home battery kWh | 274.96 | 0.046 |
| grid kWh | 1799.48 | 0.005 |
| cost | 633.01 | 0.041 |

The residuals are the 1 ms dummy meter value at the start of each process: charging process 881 kept `UsedSolarEnergyKwh = 0.000000595`, which is exactly `2142 W × 1 ms`.

## Fix

A dedicated constant that is not tied to the logging interval:

```csharp
public TimeSpan MaxMeterValueGapForEnergyCalculation => TimeSpan.FromMinutes(5);
```

Five minutes covers every interval TSC has used so far while still ignoring meter values after a real pause. The energy calculation is extracted into `CalculateChargedEnergyAndCost` so it can be tested without a database.

## Verification against the reporter's data

Re-integrating the untouched `MeterValues` of charging process 881 with different thresholds:

| | solar | grid | battery | skipped |
|---|---|---|---|---|
| stored before the data loss | 8.67228061 | 0.55251891 | 0.62776671 | — |
| threshold 21 s (before this PR) | 0.00000060 | 0.0 | 0.0 | **135 of 137** |
| threshold 5 min (this PR) | 8.67227690 | 0.55251848 | 0.62776747 | 0 |

Same result for sampled charging processes from 2024-12, 2025-04 and 2025-08. Charging processes recorded with the current interval are bit identical under both thresholds.

Across ten months of current-interval data, widening the threshold adds 0.42 kWh out of 3473.59 kWh — energy that is currently discarded rather than counted.

## Recovery

`MeterValues` was never modified, only the four aggregate columns on `ChargingProcesses`. Affected users get their data back by triggering a recalculation once (save any charge price). Of the reporter's 881 damaged charging processes, 770 can be rebuilt and hold all of the lost energy; the remaining 111 are degenerate zero length processes that never held any.

A follow-up should run this recalculation automatically once after the update, since most affected users will not know that saving a price repairs their history.

## Tests

- `CalculateChargedEnergyAndCost_UsesMeterValuesOfAnyLoggingInterval` covers both the 59 s and the 11 s interval. With the old threshold restored it fails with `Expected: 4425, Actual: 0` for 59 s and passes for 11 s.
- `CalculateChargedEnergyAndCost_IgnoresMeterValuesAfterALongPause` keeps the original intent of the guard.

964 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
