### PR TITLE
fix(BLE): presence error never cleared, and an unreachable container burnt the whole timeout

### DIFF
--- a/TeslaSolarCharger.Tests/Services/Server/BleVehicleDataServiceTests.cs
+++ b/TeslaSolarCharger.Tests/Services/Server/BleVehicleDataServiceTests.cs
@@ -299,6 +299,30 @@ public class BleVehicleDataServiceTests : TestBase
         Assert.Empty(Context.CarValueLogs.ToList());
     }
 
+    /// <summary>
+    /// A presence request that failed while the car was already gone used to leave an error open until the car came
+    /// back and was read successfully, which can be days: only the one shot away transition resolved it.
+    /// </summary>
+    [Theory]
+    [InlineData(BlePresenceDecision.JustConfirmedAway)]
+    [InlineData(BlePresenceDecision.AlreadyAway)]
+    [InlineData(BlePresenceDecision.Uncertain)]
+    [InlineData(BlePresenceDecision.Unknown)]
+    public async Task ACarThatIsNotReadHasNoOpenDataCollectionError(BlePresenceDecision decision)
+    {
+        var dtoCar = SetupBleDataCollectionCar();
+        SetupPresence(present: false);
+        Mock.Mock<IBlePresenceStateService>().Setup(p => p.RegisterPresenceAge(dtoCar.Id, It.IsAny<TimeSpan?>(), It.IsAny<TimeSpan>()))
+            .Returns(decision);
+
+        var service = Mock.Create<TeslaSolarCharger.Server.Services.BleVehicleDataService>();
+        await service.RefreshBleCarData();
+
+        //The container answered and the car was not talked to at all, so nothing can currently be failing.
+        Mock.Mock<IErrorHandlingService>().Verify(e => e.HandleErrorResolved(
+            Mock.Create<IIssueKeys>().BleDataCollectionError, TestVin), Times.Once);
+    }
+
     [Fact]
     public async Task ScanThatCouldNotRunDoesNotChangePresence()
     {

--- a/TeslaSolarCharger/Server/ServiceCollectionExtensions.cs
+++ b/TeslaSolarCharger/Server/ServiceCollectionExtensions.cs
@@ -255,9 +255,18 @@ public static class ServiceCollectionExtensions
         });
         //Per call timeouts are set via CancellationTokenSource, this is only a backstop.
         services.AddHttpClient(StaticConstants.HttpClientNameBle, client =>
-        {
-            client.Timeout = TimeSpan.FromSeconds(120);
-        });
+            {
+                client.Timeout = TimeSpan.FromSeconds(120);
+            })
+            //A BLE container that dropped off the network - a Raspberry Pi whose WiFi de-associated is the usual case -
+            //answers no SYN at all, and .NET waits for a connection without a limit by default. Every call to that
+            //container would then burn its full per call budget in the connection pool instead of failing while the
+            //next scheduled poll can still succeed. A handshake on a LAN takes milliseconds, so five seconds is
+            //generous even for a busy Raspberry Pi Zero.
+            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+            {
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+            });
         services.AddHttpClient();
         return services;
     }

--- a/TeslaSolarCharger/Server/Services/BleVehicleDataService.cs
+++ b/TeslaSolarCharger/Server/Services/BleVehicleDataService.cs
@@ -317,7 +317,6 @@ public class BleVehicleDataService(
                 UpdateOnlineState(car, false, timestamp);
                 ResetChargingValuesForAwayCar(car, timestamp);
                 await teslaSolarChargerContext.SaveChangesAsync().ConfigureAwait(false);
-                await errorHandlingService.HandleErrorResolved(issueKeys.BleDataCollectionError, vin).ConfigureAwait(false);
                 break;
             case BlePresenceDecision.AlreadyAway:
                 //The car is already marked as away: nothing changed, so do not write the same values again.
@@ -333,6 +332,11 @@ public class BleVehicleDataService(
                 logger.LogDebug("Car {vin} not heard, keeping last known state until the away state is confirmed", vin);
                 break;
         }
+        //Getting here means the container answered and the car was not read at all, so nothing can currently be wrong
+        //with its data collection. Resolving only on the away transition left an error raised while the car was
+        //already gone - a presence request that timed out because the container dropped off the network, say - open
+        //until the car came back and was read successfully, which can be days.
+        await errorHandlingService.HandleErrorResolved(issueKeys.BleDataCollectionError, vin).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/TeslaSolarCharger/Server/Services/TeslaBleService.cs
+++ b/TeslaSolarCharger/Server/Services/TeslaBleService.cs
@@ -355,7 +355,13 @@ public class TeslaBleService(ILogger<TeslaBleService> logger,
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to get BLE presence.");
-            return new DtoBlePresenceResult { ErrorMessage = ex.Message };
+            //A timed out HttpClient call says "A task was canceled.", which tells nobody what to look at. No external
+            //token is passed in, so a cancellation here can only be the timeout above.
+            var errorMessage = cancellationTokenSource.IsCancellationRequested
+                ? $"The BLE container at {bleBaseUrl} did not answer within {CommandTimeout.TotalSeconds:0} seconds. " +
+                  "Check that the container is running and that its host is reachable over the network."
+                : ex.Message;
+            return new DtoBlePresenceResult { ErrorMessage = errorMessage };
         }
     }
 


### PR DESCRIPTION
## The symptom

On a live instance: `Error while getting vehicle data via BLE for car XP7YGCEK7PB182221`, message `BLE presence could not be determined: A task was canceled.`, 66 occurrences, and it never cleared.

## Two causes

**The presence request times out.** The BLE container's host drops off the network in bursts. Measured on the live setup: 3 of 90 `curl` connects to the container failed outright, `ping` lost 47 of 400 packets in two contiguous blocks (16 s and 32 s) including `Destination host unreachable` from the router, and gap analysis of the container's own inbound `Presence(` arrivals shows the same windows every 5-8 min, each followed by 2-3 requests landing within ~20 ms of each other. The container logged its scan digests continuously through every gap, so container and OS were healthy - the host was simply not on the network.

The SYN is black-holed rather than rejected, so nothing returns `EHOSTUNREACH`. `HttpConnectionPool` waits for a connection instead, and TSC's own 29 s `CommandTimeout` fires with the useless `A task was canceled.`

**The error can never clear for an away car.** `HandleAbsentCar` resolved `BleDataCollectionError` only in the one shot `JustConfirmedAway` branch. `AlreadyAway`, `Uncertain` and `Unknown` resolved nothing, and the only other resolve sites are the successful read paths. So an error raised *after* the away transition stayed open until the car came home and was read successfully - days, in the observed case.

## The changes

- `BleVehicleDataService.HandleAbsentCar` resolves the error for every non-`Present` decision: the container answered and the car was not talked to, so nothing can currently be failing. Because `ShowErrorAfterOccurrences` is 3 for this key, isolated single poll failures now stay hidden and only three or more consecutive ones surface.
- The BLE `HttpClient` gets a `SocketsHttpHandler` with `ConnectTimeout = 5 s`. Without it .NET waits for a connection unboundedly and one dropped SYN costs the caller's full budget.
- `GetPresence` replaces `A task was canceled.` with a message naming the container URL and the timeout.

## Not covered

The host's network flapping itself - that is an infrastructure problem, this only stops TSC from accumulating a permanent error over it. Also left alone: the container's `/presence` calls `EnsureWorkerStartedForScanning`, which can block up to `WorkerReadyTimeoutSeconds` (30 s), longer than TSC's budget. Ruled out as this cause by the container's continuous logging, but making that start fire and forget is the obvious follow up.

## Tests

Four new theory cases covering every non-`Present` decision. Full suite: 968 tests, 0 failures, 3 pre-existing intentional skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
